### PR TITLE
Fixes #10 (Now compatible with immutable library)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules
 npm-debug.log
 .DS_Store
-lib

--- a/lib/ActionList.js
+++ b/lib/ActionList.js
@@ -1,0 +1,77 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _extends2 = require('babel-runtime/helpers/extends');
+
+var _extends3 = _interopRequireDefault(_extends2);
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _dateformat = require('dateformat');
+
+var _dateformat2 = _interopRequireDefault(_dateformat);
+
+var _themeable = require('./themeable');
+
+var _themeable2 = _interopRequireDefault(_themeable);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function getTime(actions, actionIds, actionId) {
+  var idx = actionIds.indexOf(actionId);
+  var prevActionId = actionIds[idx - 1];
+
+  return idx ? (0, _dateformat2.default)(actions[actionId].timestamp - actions[prevActionId].timestamp, '+MM:ss.L') : (0, _dateformat2.default)(actions[actionId].timestamp, 'h:MM:ss.L');
+}
+
+var ActionList = function ActionList(_ref) {
+  var theme = _ref.theme;
+  var defaultTheme = _ref.defaultTheme;
+  var actions = _ref.actions;
+  var actionIds = _ref.actionIds;
+  var isWideLayout = _ref.isWideLayout;
+  var selectedActionId = _ref.selectedActionId;
+  var onSelect = _ref.onSelect;
+  var onSearch = _ref.onSearch;
+  var searchValue = _ref.searchValue;
+
+  var createTheme = (0, _themeable2.default)((0, _extends3.default)({}, theme, defaultTheme));
+  var lowerSearchValue = searchValue && searchValue.toLowerCase();
+  var filteredActionIds = searchValue ? actionIds.filter(function (id) {
+    return actions[id].action.type.toLowerCase().indexOf(lowerSearchValue) !== -1;
+  }) : actionIds;
+
+  return _react2.default.createElement(
+    'div',
+    (0, _extends3.default)({ key: 'actionList'
+    }, createTheme('actionList', isWideLayout && 'actionListWide')),
+    _react2.default.createElement('input', (0, _extends3.default)({}, createTheme('actionListSearch'), {
+      onChange: function onChange(e) {
+        return onSearch(e.target.value);
+      },
+      placeholder: 'filter...' })),
+    filteredActionIds.map(function (actionId) {
+      return _react2.default.createElement(
+        'div',
+        (0, _extends3.default)({ key: actionId
+        }, createTheme('actionListItem', actionId === selectedActionId && 'actionListItemSelected'), {
+          onClick: function onClick() {
+            return onSelect(actionId);
+          } }),
+        actions[actionId].action.type,
+        _react2.default.createElement(
+          'div',
+          createTheme('actionListItemTime'),
+          getTime(actions, actionIds, actionId)
+        )
+      );
+    })
+  );
+};
+
+exports.default = ActionList;

--- a/lib/ActionPreview.js
+++ b/lib/ActionPreview.js
@@ -1,0 +1,214 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _toConsumableArray2 = require('babel-runtime/helpers/toConsumableArray');
+
+var _toConsumableArray3 = _interopRequireDefault(_toConsumableArray2);
+
+var _extends2 = require('babel-runtime/helpers/extends');
+
+var _extends3 = _interopRequireDefault(_extends2);
+
+var _keys = require('babel-runtime/core-js/object/keys');
+
+var _keys2 = _interopRequireDefault(_keys);
+
+var _typeof2 = require('babel-runtime/helpers/typeof');
+
+var _typeof3 = _interopRequireDefault(_typeof2);
+
+var _defineProperty2 = require('babel-runtime/helpers/defineProperty');
+
+var _defineProperty3 = _interopRequireDefault(_defineProperty2);
+
+var _getIterator2 = require('babel-runtime/core-js/get-iterator');
+
+var _getIterator3 = _interopRequireDefault(_getIterator2);
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _themeable = require('./themeable');
+
+var _themeable2 = _interopRequireDefault(_themeable);
+
+var _diffpatcher = require('jsondiffpatch/src/diffpatcher');
+
+var _leonavesReactJsonTree = require('leonaves-react-json-tree');
+
+var _leonavesReactJsonTree2 = _interopRequireDefault(_leonavesReactJsonTree);
+
+var _ActionPreviewHeader = require('./ActionPreviewHeader');
+
+var _ActionPreviewHeader2 = _interopRequireDefault(_ActionPreviewHeader);
+
+var _JSONDiff = require('./JSONDiff');
+
+var _JSONDiff2 = _interopRequireDefault(_JSONDiff);
+
+var _deepMap = require('./deepMap');
+
+var _deepMap2 = _interopRequireDefault(_deepMap);
+
+var _objType = require('./obj-type');
+
+var _objType2 = _interopRequireDefault(_objType);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var jsonDiff = new _diffpatcher.DiffPatcher({});
+
+function getInspectedState(state, path, purgeFunctions) {
+  state = path.length ? (0, _defineProperty3.default)({}, path[path.length - 1], path.reduce(function (s, key) {
+    if ((0, _objType2.default)(s) === 'Iterable') {
+      var i = 0;var _iteratorNormalCompletion = true;
+      var _didIteratorError = false;
+      var _iteratorError = undefined;
+
+      try {
+        for (var _iterator = (0, _getIterator3.default)(s), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+          var entry = _step.value;
+
+          if (Array.isArray(entry)) {
+            if (entry[0] === key) return entry[1];
+          } else {
+            if (i > key) return;if (i === key) return entry;
+          }i++;
+        }
+      } catch (err) {
+        _didIteratorError = true;
+        _iteratorError = err;
+      } finally {
+        try {
+          if (!_iteratorNormalCompletion && _iterator.return) {
+            _iterator.return();
+          }
+        } finally {
+          if (_didIteratorError) {
+            throw _iteratorError;
+          }
+        }
+      }
+    } else if ((0, _objType2.default)(s) === 'Immutable_Iterable') {
+      return s && s.get(key);
+    } else {
+      return s && s[key];
+    }
+  }, state)) : state;
+
+  return purgeFunctions ? (0, _deepMap2.default)(state, function (val) {
+    return typeof val === 'function' ? 'fn()' : val;
+  }) : state;
+}
+
+function _getItemString(createTheme, type, data) {
+  var text = undefined;
+
+  function getShortTypeString(val) {
+    if (Array.isArray(val)) {
+      return val.length > 0 ? '[…]' : '[]';
+    } else if (val === null) {
+      return 'null';
+    } else if (val === undefined) {
+      return 'undef';
+    } else if ((typeof val === 'undefined' ? 'undefined' : (0, _typeof3.default)(val)) === 'object') {
+      return (0, _keys2.default)(val).length > 0 ? '{…}' : '{}';
+    } else if (typeof val === 'function') {
+      return 'fn';
+    } else if (typeof val === 'string') {
+      return '"' + (val.substr(0, 10) + (val.length > 10 ? '…' : '')) + '"';
+    } else {
+      return val;
+    }
+  }
+
+  if (type === 'Object') {
+    var keys = (0, _keys2.default)(data);
+    var str = keys.slice(0, 2).map(function (key) {
+      return key + ': ' + getShortTypeString(data[key]);
+    }).concat(keys.length > 2 ? ['…'] : []).join(', ');
+
+    text = '{ ' + str + ' }';
+  } else if (type === 'Array') {
+    var str = data.slice(0, 2).map(getShortTypeString).concat(data.length > 2 ? ['…'] : []).join(', ');
+
+    text = '[' + str + ']';
+  } else {
+    text = type;
+  }
+
+  return _react2.default.createElement(
+    'span',
+    createTheme('treeItemHint'),
+    ' ',
+    text
+  );
+}
+
+var ActionPreview = function ActionPreview(_ref2) {
+  var theme = _ref2.theme;
+  var defaultTheme = _ref2.defaultTheme;
+  var fromState = _ref2.fromState;
+  var toState = _ref2.toState;
+  var onInspectPath = _ref2.onInspectPath;
+  var inspectedPath = _ref2.inspectedPath;
+  var tab = _ref2.tab;
+  var onSelectTab = _ref2.onSelectTab;
+
+
+  var createTheme = (0, _themeable2.default)((0, _extends3.default)({}, theme, defaultTheme));
+  var delta = fromState && toState && jsonDiff.diff(getInspectedState(fromState.state, inspectedPath, true), getInspectedState(toState.state, inspectedPath, true));
+
+  var labelRenderer = function labelRenderer(key) {
+    for (var _len = arguments.length, rest = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+      rest[_key - 1] = arguments[_key];
+    }
+
+    return _react2.default.createElement(
+      'span',
+      null,
+      _react2.default.createElement(
+        'span',
+        createTheme('treeItemKey'),
+        key
+      ),
+      _react2.default.createElement(
+        'span',
+        (0, _extends3.default)({}, createTheme('treeItemPin'), {
+          onClick: function onClick() {
+            return onInspectPath([].concat((0, _toConsumableArray3.default)(inspectedPath.slice(0, inspectedPath.length - 1)), (0, _toConsumableArray3.default)([key].concat(rest).reverse())));
+          } }),
+        '(pin)'
+      )
+    );
+  };
+
+  return _react2.default.createElement(
+    'div',
+    (0, _extends3.default)({ key: 'actionPreview' }, createTheme('actionPreview')),
+    _react2.default.createElement(_ActionPreviewHeader2.default, {
+      theme: theme, defaultTheme: defaultTheme, inspectedPath: inspectedPath, onInspectPath: onInspectPath, tab: tab, onSelectTab: onSelectTab
+    }),
+    tab === 'Diff' && delta && _react2.default.createElement(_JSONDiff2.default, { delta: delta, labelRenderer: labelRenderer, theme: theme, defaultTheme: defaultTheme }),
+    tab === 'Diff' && !delta && _react2.default.createElement(
+      'div',
+      createTheme('stateDiffEmpty'),
+      '(states are equal)'
+    ),
+    tab === 'State' && toState && _react2.default.createElement(_leonavesReactJsonTree2.default, { labelRenderer: labelRenderer,
+      data: getInspectedState(toState.state, inspectedPath),
+      getItemString: function getItemString(type, data) {
+        return _getItemString(createTheme, type, data);
+      },
+      getItemStringStyle: function getItemStringStyle(type, expanded) {
+        return { display: expanded ? 'none' : 'inline' };
+      },
+      hideRoot: true })
+  );
+};
+
+exports.default = ActionPreview;

--- a/lib/ActionPreviewHeader.js
+++ b/lib/ActionPreviewHeader.js
@@ -1,0 +1,83 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _extends2 = require('babel-runtime/helpers/extends');
+
+var _extends3 = _interopRequireDefault(_extends2);
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _themeable = require('./themeable');
+
+var _themeable2 = _interopRequireDefault(_themeable);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var ActionPreviewHeader = function ActionPreviewHeader(_ref) {
+  var theme = _ref.theme;
+  var defaultTheme = _ref.defaultTheme;
+  var inspectedPath = _ref.inspectedPath;
+  var onInspectPath = _ref.onInspectPath;
+  var tab = _ref.tab;
+  var onSelectTab = _ref.onSelectTab;
+
+  var createTheme = (0, _themeable2.default)((0, _extends3.default)({}, theme, defaultTheme));
+
+  return _react2.default.createElement(
+    'div',
+    (0, _extends3.default)({ key: 'previewHeader' }, createTheme('previewHeader')),
+    _react2.default.createElement(
+      'div',
+      null,
+      inspectedPath.length ? _react2.default.createElement(
+        'span',
+        createTheme('inspectedPathKey'),
+        _react2.default.createElement(
+          'a',
+          (0, _extends3.default)({ onClick: function onClick() {
+              return onInspectPath([]);
+            }
+          }, createTheme('inspectedPathKeyLink')),
+          tab
+        )
+      ) : tab,
+      inspectedPath.map(function (key, idx) {
+        return idx === inspectedPath.length - 1 ? key : _react2.default.createElement(
+          'span',
+          (0, _extends3.default)({ key: key
+          }, createTheme('inspectedPathKey')),
+          _react2.default.createElement(
+            'a',
+            (0, _extends3.default)({ onClick: function onClick() {
+                return onInspectPath(inspectedPath.slice(0, idx + 1));
+              }
+            }, createTheme('inspectedPathKeyLink')),
+            key
+          )
+        );
+      })
+    ),
+    _react2.default.createElement(
+      'div',
+      createTheme('tabSelector'),
+      ['Diff', 'State'].map(function (t) {
+        return _react2.default.createElement(
+          'div',
+          (0, _extends3.default)({ onClick: function onClick() {
+              return onSelectTab(t);
+            },
+            key: t
+          }, createTheme('tabSelectorButton', t === tab && 'tabSelectorButtonSelected')),
+          t
+        );
+      })
+    )
+  );
+};
+
+exports.default = ActionPreviewHeader;

--- a/lib/DevtoolsInspector.js
+++ b/lib/DevtoolsInspector.js
@@ -1,0 +1,174 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _extends2 = require('babel-runtime/helpers/extends');
+
+var _extends3 = _interopRequireDefault(_extends2);
+
+var _getPrototypeOf = require('babel-runtime/core-js/object/get-prototype-of');
+
+var _getPrototypeOf2 = _interopRequireDefault(_getPrototypeOf);
+
+var _classCallCheck2 = require('babel-runtime/helpers/classCallCheck');
+
+var _classCallCheck3 = _interopRequireDefault(_classCallCheck2);
+
+var _createClass2 = require('babel-runtime/helpers/createClass');
+
+var _createClass3 = _interopRequireDefault(_createClass2);
+
+var _possibleConstructorReturn2 = require('babel-runtime/helpers/possibleConstructorReturn');
+
+var _possibleConstructorReturn3 = _interopRequireDefault(_possibleConstructorReturn2);
+
+var _inherits2 = require('babel-runtime/helpers/inherits');
+
+var _inherits3 = _interopRequireDefault(_inherits2);
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _themeable = require('./themeable');
+
+var _themeable2 = _interopRequireDefault(_themeable);
+
+var _defaultTheme = require('./defaultTheme');
+
+var _defaultTheme2 = _interopRequireDefault(_defaultTheme);
+
+var _function = require('react-pure-render/function');
+
+var _function2 = _interopRequireDefault(_function);
+
+var _ActionList = require('./ActionList');
+
+var _ActionList2 = _interopRequireDefault(_ActionList);
+
+var _ActionPreview = require('./ActionPreview');
+
+var _ActionPreview2 = _interopRequireDefault(_ActionPreview);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var DevtoolsInspector = function (_Component) {
+  (0, _inherits3.default)(DevtoolsInspector, _Component);
+
+  function DevtoolsInspector(props) {
+    (0, _classCallCheck3.default)(this, DevtoolsInspector);
+
+    var _this = (0, _possibleConstructorReturn3.default)(this, (0, _getPrototypeOf2.default)(DevtoolsInspector).call(this, props));
+
+    _this.shouldComponentUpdate = _function2.default;
+
+    _this.state = {
+      isWideLayout: false,
+      selectedActionId: null,
+      inspectedPath: [],
+      tab: 'State'
+    };
+    return _this;
+  }
+
+  (0, _createClass3.default)(DevtoolsInspector, [{
+    key: 'componentDidMount',
+    value: function componentDidMount() {
+      var _this2 = this;
+
+      this.updateSizeTimeout = window.setInterval(function () {
+        return _this2.updateSizeMode();
+      }, 150);
+    }
+  }, {
+    key: 'componentWillUnmount',
+    value: function componentWillUnmount() {
+      window.clearTimeout(this.updateSizeTimeout);
+    }
+  }, {
+    key: 'updateSizeMode',
+    value: function updateSizeMode() {
+      this.setState({
+        isWideLayout: this.refs.inspector.offsetWidth > 500
+      });
+    }
+  }, {
+    key: 'render',
+    value: function render() {
+      var _this3 = this;
+
+      var _props = this.props;
+      var theme = _props.theme;
+      var actionIds = _props.stagedActionIds;
+      var actions = _props.actionsById;
+      var computedStates = _props.computedStates;
+      var _state = this.state;
+      var isWideLayout = _state.isWideLayout;
+      var selectedActionId = _state.selectedActionId;
+      var inspectedPath = _state.inspectedPath;
+      var searchValue = _state.searchValue;
+      var tab = _state.tab;
+
+      var createTheme = (0, _themeable2.default)((0, _extends3.default)({}, theme, _defaultTheme2.default));
+      var lastActionId = actionIds[actionIds.length - 1];
+      var currentActionId = selectedActionId === null ? lastActionId : selectedActionId;
+
+      return _react2.default.createElement(
+        'div',
+        (0, _extends3.default)({ key: 'inspector'
+        }, createTheme('inspector', isWideLayout && 'inspectorWide'), {
+          ref: 'inspector' }),
+        _react2.default.createElement(_ActionList2.default, (0, _extends3.default)({ theme: theme, defaultTheme: _defaultTheme2.default, actions: actions, actionIds: actionIds, isWideLayout: isWideLayout, searchValue: searchValue }, {
+          selectedActionId: selectedActionId,
+          onSearch: function onSearch(val) {
+            return _this3.setState({ searchValue: val });
+          },
+          onSelect: function onSelect(actionId) {
+            return _this3.setState({
+              selectedActionId: actionId === selectedActionId ? null : actionId
+            });
+          } })),
+        _react2.default.createElement(_ActionPreview2.default, (0, _extends3.default)({ theme: theme, defaultTheme: _defaultTheme2.default, tab: tab }, {
+          fromState: currentActionId > 0 ? computedStates[currentActionId - 1] : null,
+          toState: computedStates[currentActionId],
+          onInspectPath: function onInspectPath(path) {
+            return _this3.setState({ inspectedPath: path });
+          },
+          inspectedPath: inspectedPath,
+          onSelectTab: function onSelectTab(tab) {
+            return _this3.setState({ tab: tab });
+          } }))
+      );
+    }
+  }]);
+  return DevtoolsInspector;
+}(_react.Component);
+
+DevtoolsInspector.propTypes = {
+  dispatch: _react.PropTypes.func,
+  computedStates: _react.PropTypes.array,
+  stagedActionIds: _react.PropTypes.array,
+  actionsById: _react.PropTypes.object,
+  currentStateIndex: _react.PropTypes.number,
+  monitorState: _react.PropTypes.shape({
+    initialScrollTop: _react.PropTypes.number
+  }),
+  preserveScrollTop: _react.PropTypes.bool,
+  stagedActions: _react.PropTypes.array,
+  select: _react.PropTypes.func.isRequired,
+  theme: _react.PropTypes.oneOfType([_react.PropTypes.object, _react.PropTypes.string])
+};
+
+DevtoolsInspector.update = function (s) {
+  return s;
+};
+
+DevtoolsInspector.defaultProps = {
+  theme: {},
+  select: function select(state) {
+    return state;
+  }
+};
+exports.default = DevtoolsInspector;

--- a/lib/JSONDiff.js
+++ b/lib/JSONDiff.js
@@ -1,0 +1,141 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _objectWithoutProperties2 = require('babel-runtime/helpers/objectWithoutProperties');
+
+var _objectWithoutProperties3 = _interopRequireDefault(_objectWithoutProperties2);
+
+var _defineProperty2 = require('babel-runtime/helpers/defineProperty');
+
+var _defineProperty3 = _interopRequireDefault(_defineProperty2);
+
+var _extends5 = require('babel-runtime/helpers/extends');
+
+var _extends6 = _interopRequireDefault(_extends5);
+
+var _keys = require('babel-runtime/core-js/object/keys');
+
+var _keys2 = _interopRequireDefault(_keys);
+
+var _stringify = require('babel-runtime/core-js/json/stringify');
+
+var _stringify2 = _interopRequireDefault(_stringify);
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _leonavesReactJsonTree = require('leonaves-react-json-tree');
+
+var _leonavesReactJsonTree2 = _interopRequireDefault(_leonavesReactJsonTree);
+
+var _deepMap = require('./deepMap');
+
+var _deepMap2 = _interopRequireDefault(_deepMap);
+
+var _themeable = require('./themeable');
+
+var _themeable2 = _interopRequireDefault(_themeable);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function stringify(val) {
+  var str = (0, _stringify2.default)(val);
+
+  return str.length > 22 ? str.substr(0, 15) + '…' + str.substr(-5) : str;
+}
+
+function prepareDelta(delta) {
+  var diffs = [];
+  var diffId = -1;
+  var data = (0, _deepMap2.default)(delta, function (val) {
+    if (Array.isArray(val)) {
+      diffs.push(val);
+      diffId++;
+      return '<JSON_DIFF_ID>' + diffId;
+    }
+
+    if (val && val._t === 'a') {
+      return (0, _keys2.default)(val).reduce(function (obj, key) {
+        if (key === '_t') {
+          return obj;
+        }if (key[0] === '_' && !val[key.substr(1)]) {
+          return (0, _extends6.default)({}, obj, (0, _defineProperty3.default)({}, key.substr(1), val[key]));
+        } else if (val['_' + key]) {
+          return (0, _extends6.default)({}, obj, (0, _defineProperty3.default)({}, key, [val['_' + key][0], val[key][0]]));
+        } else if (!val['_' + key] && key[0] !== '_') {
+          return (0, _extends6.default)({}, obj, (0, _defineProperty3.default)({}, key, val[key]));
+        }
+
+        return obj;
+      }, {});
+    }
+
+    return val;
+  });
+
+  return { diffs: diffs, data: data };
+}
+
+function _valueRenderer(raw, diffs, createTheme) {
+  function renderSpan(name, body) {
+    return _react2.default.createElement(
+      'span',
+      (0, _extends6.default)({ key: name }, createTheme('diff', name)),
+      body
+    );
+  }
+
+  if (raw.indexOf('"<JSON_DIFF_ID>') === 0) {
+    var diff = diffs[parseInt(raw.replace(/[^\d]/g, ''), 10)];
+
+    if (Array.isArray(diff)) {
+      switch (diff.length) {
+        case 1:
+          return renderSpan('diffAdd', stringify(diff[0]));
+        case 2:
+          return _react2.default.createElement(
+            'span',
+            null,
+            renderSpan('diffUpdateFrom', stringify(diff[0])),
+            renderSpan('diffUpdateArrow', ' => '),
+            renderSpan('diffUpdateTo', stringify(diff[1]))
+          );
+        case 3:
+          return renderSpan('diffRemove', stringify(diff[0]));
+      }
+    }
+  }
+
+  return raw;
+}
+
+var JSONDiff = function JSONDiff(_ref) {
+  var delta = _ref.delta;
+  var theme = _ref.theme;
+  var defaultTheme = _ref.defaultTheme;
+  var props = (0, _objectWithoutProperties3.default)(_ref, ['delta', 'theme', 'defaultTheme']);
+
+  var _prepareDelta = prepareDelta(delta);
+
+  var data = _prepareDelta.data;
+  var diffs = _prepareDelta.diffs;
+
+  var createTheme = (0, _themeable2.default)((0, _extends6.default)({}, theme, defaultTheme));
+
+  return _react2.default.createElement(_leonavesReactJsonTree2.default, (0, _extends6.default)({}, props, {
+    data: data,
+    getItemString: function getItemString() {
+      return '';
+    },
+    valueRenderer: function valueRenderer(raw) {
+      return _valueRenderer(raw, diffs, createTheme);
+    },
+    expandAll: true,
+    hideRoot: true }));
+};
+
+exports.default = JSONDiff;

--- a/lib/deepMap.js
+++ b/lib/deepMap.js
@@ -1,0 +1,36 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _typeof2 = require('babel-runtime/helpers/typeof');
+
+var _typeof3 = _interopRequireDefault(_typeof2);
+
+exports.default = deepMap;
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function deepMap(obj, f, ctx) {
+  if (Array.isArray(obj)) {
+    return obj.map(function (val, key) {
+      val = f.call(ctx, val, key);
+      return (typeof val === 'undefined' ? 'undefined' : (0, _typeof3.default)(val)) === 'object' ? deepMap(val, f, ctx) : val;
+    });
+  } else if ((typeof obj === 'undefined' ? 'undefined' : (0, _typeof3.default)(obj)) === 'object') {
+    var res = {};
+    for (var key in obj) {
+      var val = obj[key];
+      if (val && (typeof val === 'undefined' ? 'undefined' : (0, _typeof3.default)(val)) === 'object') {
+        val = f.call(ctx, val, key);
+        res[key] = deepMap(val, f, ctx);
+      } else {
+        res[key] = f.call(ctx, val, key);
+      }
+    }
+    return res;
+  } else {
+    return obj;
+  }
+}

--- a/lib/defaultTheme.js
+++ b/lib/defaultTheme.js
@@ -1,0 +1,310 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _extends2 = require('babel-runtime/helpers/extends');
+
+var _extends3 = _interopRequireDefault(_extends2);
+
+var _jss = require('jss');
+
+var _jss2 = _interopRequireDefault(_jss);
+
+var _jssVendorPrefixer = require('jss-vendor-prefixer');
+
+var _jssVendorPrefixer2 = _interopRequireDefault(_jssVendorPrefixer);
+
+var _jssNested = require('jss-nested');
+
+var _jssNested2 = _interopRequireDefault(_jssNested);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+_jss2.default.use((0, _jssVendorPrefixer2.default)());
+_jss2.default.use((0, _jssNested2.default)());
+
+var TEXT_COLOR = '#666';
+var BACKGROUND_COLOR = '#FFF';
+var SELECTED_BACKGROUND_COLOR = '#F0F0F0';
+var HEADER_BACKGROUND_COLOR = '#FAFAFA';
+var BORDER_COLOR = '#DDD';
+var ACTION_TIME_BACK_COLOR = '#EEE';
+var ACTION_TIME_COLOR = '#777';
+var PIN_COLOR = '#AAA';
+var ITEM_HINT_COLOR = '#AAE';
+var TAB_BACK_COLOR = '#F6F6F6';
+var TAB_HOVER_BACK_COLOR = '#FFF';
+var DIFF_ADD_BACK_COLOR = '#AFA';
+var DIFF_UPDATE_BACK_COLOR = '#FFA';
+var DIFF_REMOVE_BACK_COLOR = '#FAA';
+var DIFF_ADD_COLOR = '#393';
+var DIFF_REMOVE_COLOR = '#933';
+var DIFF_ARROW_COLOR = '#999';
+var LINK_COLOR = '#0a6ebd';
+
+var colors = {
+  inspectorColor: {
+    'background-color': BACKGROUND_COLOR,
+    color: TEXT_COLOR
+  },
+
+  actionListColor: {
+    'background-color': BACKGROUND_COLOR,
+    'border-color': BORDER_COLOR
+  },
+
+  actionListItemColor: {
+    'border-bottom-color': BORDER_COLOR
+  },
+
+  actionListItemSelectedColor: {
+    'background-color': SELECTED_BACKGROUND_COLOR
+  },
+
+  actionListItemTimeColor: {
+    'background-color': ACTION_TIME_BACK_COLOR,
+    color: ACTION_TIME_COLOR
+  },
+
+  actionPreviewColor: {
+    'background-color': BACKGROUND_COLOR
+  },
+
+  stateDiffEmptyColor: {
+    color: '#AAA'
+  },
+
+  inspectedPathColor: {
+    'background-color': HEADER_BACKGROUND_COLOR,
+    'border-color': BORDER_COLOR
+  },
+
+  treeItemPinColor: {
+    color: PIN_COLOR
+  },
+
+  previewHeaderColor: {
+    'background-color': HEADER_BACKGROUND_COLOR,
+    'border-bottom': BORDER_COLOR
+  },
+
+  treeItemHintColor: {
+    color: ITEM_HINT_COLOR
+  },
+
+  tabSelectorButtonColor: {
+    'border-color': BORDER_COLOR,
+    'background-color': TAB_BACK_COLOR,
+    '&:hover': {
+      'background-color': TAB_HOVER_BACK_COLOR
+    }
+  },
+
+  tabSelectorButtonSelectedColor: {
+    'background-color': TAB_HOVER_BACK_COLOR
+  },
+
+  diffColor: {
+    color: TEXT_COLOR
+  },
+
+  diffAddColor: {
+    'background-color': DIFF_ADD_BACK_COLOR
+  },
+
+  diffRemoveColor: {
+    'background-color': DIFF_REMOVE_BACK_COLOR
+  },
+
+  diffUpdateFromColor: {
+    color: DIFF_REMOVE_COLOR,
+    'text-decoration': 'line-through',
+    'background-color': DIFF_UPDATE_BACK_COLOR
+  },
+
+  diffUpdateToColor: {
+    color: DIFF_ADD_COLOR,
+    'background-color': DIFF_UPDATE_BACK_COLOR
+  },
+
+  diffUpdateArrowColor: {
+    color: DIFF_ARROW_COLOR
+  },
+
+  inspectedPathKeyLinkColor: {
+    color: LINK_COLOR
+  },
+
+  actionListSearchColor: {
+    'border-color': BORDER_COLOR
+  }
+};
+
+var styles = {
+  inspector: {
+    display: 'flex',
+    'flex-direction': 'column',
+    width: '100%',
+    height: '100%',
+    'font-family': 'monaco, Consolas, "Lucida Console", monospace',
+    'font-size': '12px',
+    'font-smoothing': 'antialiased',
+    'line-height': '1.5em'
+  },
+
+  actionListItem: {
+    'border-bottom-width': '1px',
+    'border-bottom-style': 'solid',
+    display: 'flex',
+    'align-items': 'flex-start',
+    'justify-content': 'space-between',
+    padding: '0.5rem 1rem',
+    cursor: 'pointer',
+
+    '&:last-child': {
+      'border-bottom-width': 0
+    }
+  },
+
+  actionListItemTime: {
+    padding: '0.4rem 0.6rem',
+    'border-radius': '3px',
+    'font-size': '0.8em',
+    'line-height': '1em'
+  },
+
+  actionPreview: {
+    '& pre': {
+      border: 'inherit',
+      'border-radius': '3px',
+      'line-height': 'inherit',
+      color: 'inherit'
+    }
+  },
+
+  actionList: {
+    'flex-basis': '40%',
+    'flex-shrink': 0,
+    'overflow-y': 'auto',
+    'border-bottom-width': '3px',
+    'border-bottom-style': 'double'
+  },
+
+  actionPreview: {
+    'flex-grow': 1,
+    'overflow-y': 'auto'
+  },
+
+  inspectorWide: {
+    'flex-direction': 'row'
+  },
+
+  actionListWide: {
+    'flex-basis': '40%',
+    'border-bottom': 'none',
+    'border-right-width': '3px',
+    'border-right-style': 'double'
+  },
+
+  stateDiff: {
+    padding: '0.5rem 0'
+  },
+
+  stateDiffEmpty: {
+    padding: '0.5rem 1rem'
+  },
+
+  inspectedPath: {
+    padding: '0.5rem 1rem',
+    'border-bottom-width': '1px',
+    'border-bottom-style': 'solid'
+  },
+
+  inspectedPathKey: {
+    '&:not(:last-child):after': {
+      content: '" > "'
+    }
+  },
+
+  inspectedPathKeyLink: {
+    cursor: 'pointer',
+    '&:hover': {
+      'text-decoration': 'underline'
+    }
+  },
+
+  treeItemPin: {
+    'font-size': '0.7em',
+    'padding-left': '0.5rem',
+    cursor: 'pointer',
+    '&:hover': {
+      'text-decoration': 'underline'
+    }
+  },
+
+  treeItemKey: {
+    cursor: 'pointer'
+  },
+
+  previewHeader: {
+    padding: '0.5rem 1rem',
+    display: 'flex',
+    'justify-content': 'space-between',
+    'align-items': 'center',
+    'border-bottom-width': '1px',
+    'border-bottom-style': 'solid'
+  },
+
+  actionListSearch: {
+    outline: 'none',
+    'border-top': 'none',
+    'border-left': 'none',
+    'border-right': 'none',
+    'border-bottom-width': '1px',
+    'border-bottom-style': 'solid',
+    width: '100%',
+    padding: '0.5rem 1rem'
+  },
+
+  tabSelector: {
+    display: 'flex'
+  },
+
+  tabSelectorButton: {
+    cursor: 'pointer',
+    padding: '0.5rem 1rem',
+    'border-style': 'solid',
+    'border-width': '1px',
+    'border-left-width': 0,
+
+    '&:first-child': {
+      'border-left-width': '1px',
+      'border-top-left-radius': '3px',
+      'border-bottom-left-radius': '3px'
+    },
+
+    '&:last-child': {
+      'border-top-right-radius': '3px',
+      'border-bottom-right-radius': '3px'
+    }
+  },
+
+  diff: {
+    padding: '0.2rem 0.3rem',
+    'border-radius': '3px'
+  },
+
+  diffRemove: {
+    'text-decoration': 'line-through'
+  },
+
+  diffUpdateFrom: {
+    'text-decoration': 'line-through'
+  }
+};
+
+var sheet = _jss2.default.createStyleSheet((0, _extends3.default)({}, colors, styles)).attach();
+
+exports.default = sheet.classes;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,14 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = undefined;
+
+var _DevtoolsInspector = require('./DevtoolsInspector');
+
+var _DevtoolsInspector2 = _interopRequireDefault(_DevtoolsInspector);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+exports.default = _DevtoolsInspector2.default;

--- a/lib/obj-type.js
+++ b/lib/obj-type.js
@@ -1,0 +1,24 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+var _iterator = require('babel-runtime/core-js/symbol/iterator');
+
+var _iterator2 = _interopRequireDefault(_iterator);
+
+var _typeof2 = require('babel-runtime/helpers/typeof');
+
+var _typeof3 = _interopRequireDefault(_typeof2);
+
+exports.default = function (obj) {
+    if (obj !== null && (typeof obj === 'undefined' ? 'undefined' : (0, _typeof3.default)(obj)) === 'object' && !Array.isArray(obj) && typeof obj[_iterator2.default] === 'function') {
+        return _immutable.Iterable.isIterable(obj) ? 'Immutable_Iterable' : 'Iterable';
+    }
+    return Object.prototype.toString.call(obj).slice(8, -1);
+};
+
+var _immutable = require('immutable');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }

--- a/lib/themeable.js
+++ b/lib/themeable.js
@@ -1,0 +1,44 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _extends2 = require('babel-runtime/helpers/extends');
+
+var _extends3 = _interopRequireDefault(_extends2);
+
+var _toConsumableArray2 = require('babel-runtime/helpers/toConsumableArray');
+
+var _toConsumableArray3 = _interopRequireDefault(_toConsumableArray2);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var truthy = function truthy(x) {
+  return x;
+};
+
+exports.default = function (theme) {
+  return function () {
+    var _Object;
+
+    for (var _len = arguments.length, names = Array(_len), _key = 0; _key < _len; _key++) {
+      names[_key] = arguments[_key];
+    }
+
+    var styles = names.reduce(function (arr, name) {
+      return [].concat((0, _toConsumableArray3.default)(arr), [name, name + 'Color']);
+    }, []).map(function (name) {
+      return theme[name];
+    }).filter(truthy);
+
+    var classStyles = styles.filter(function (s) {
+      return typeof s === 'string';
+    });
+    var objStyles = styles.filter(function (s) {
+      return typeof s !== 'string';
+    });
+
+    return (0, _extends3.default)({}, classStyles.length ? { className: classStyles.join(' ') } : {}, objStyles.length ? { style: (_Object = Object).assign.apply(_Object, [{}].concat((0, _toConsumableArray3.default)(objStyles))) } : {});
+  };
+};

--- a/package.json
+++ b/package.json
@@ -64,10 +64,12 @@
     "@alexkuz/react-json-tree": "^0.5.3",
     "babel-runtime": "^6.3.19",
     "dateformat": "^1.0.12",
+    "immutable": "^3.7.6",
     "jsondiffpatch": "^0.1.41",
     "jss": "^3.3.0",
     "jss-nested": "^1.0.2",
     "jss-vendor-prefixer": "^1.0.1",
+    "leonaves-react-json-tree": "^0.5.6",
     "lodash.debounce": "^4.0.3",
     "react-pure-render": "^1.0.2",
     "react-themeable": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "leonaves-redux-devtools-inspector",
+  "name": "redux-devtools-inspector",
   "version": "0.1.7",
   "description": "Redux DevTools Diff Monitor",
   "scripts": {
@@ -14,7 +14,7 @@
   },
   "main": "lib/index.js",
   "repository": {
-    "url": "https://github.com/alexkuz/redux-devtools-inspector"
+    "url": "https://github.com/leonaves/redux-devtools-inspector"
   },
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "redux-devtools-inspector",
+  "name": "leonaves-redux-devtools-inspector",
   "version": "0.1.7",
   "description": "Redux DevTools Diff Monitor",
   "scripts": {

--- a/src/ActionPreview.jsx
+++ b/src/ActionPreview.jsx
@@ -5,6 +5,7 @@ import JSONTree from '@alexkuz/react-json-tree';
 import ActionPreviewHeader from './ActionPreviewHeader';
 import JSONDiff from './JSONDiff';
 import deepMap from './deepMap';
+import objType from './obj-type';
 
 const jsonDiff = new DiffPatcher({});
 
@@ -69,6 +70,10 @@ function getItemString(createTheme, type, data) {
 const ActionPreview = ({
   theme, defaultTheme, fromState, toState, onInspectPath, inspectedPath, tab, onSelectTab
 }) => {
+  [ fromState, toState ] = [ fromState, toState ].map(o => {
+    o = Object.assign({}, o);
+    if (objType(o.state) === 'Iterable') o.state = o.state.toJS(); return o;
+  });
   const createTheme = themeable({ ...theme, ...defaultTheme });
   const delta = fromState && toState && jsonDiff.diff(
     getInspectedState(fromState.state, inspectedPath, true),

--- a/src/DevtoolsInspector.js
+++ b/src/DevtoolsInspector.js
@@ -12,7 +12,7 @@ export default class DevtoolsInspector extends Component {
       isWideLayout: false,
       selectedActionId: null,
       inspectedPath: [],
-      tab: 'Diff'
+      tab: 'State'
     };
   }
 

--- a/src/JSONDiff.jsx
+++ b/src/JSONDiff.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import JSONTree from '@alexkuz/react-json-tree';
+import JSONTree from 'leonaves-react-json-tree';
 import deepMap from './deepMap';
 import themeable from './themeable';
 

--- a/src/obj-type.js
+++ b/src/obj-type.js
@@ -1,0 +1,8 @@
+export default function(obj) {
+    if (obj !== null && typeof obj === 'object' && !Array.isArray(obj) &&
+        typeof obj[Symbol.iterator] === 'function'
+    ) {
+        return 'Iterable';
+    }
+    return Object.prototype.toString.call(obj).slice(8, -1);
+}

--- a/src/obj-type.js
+++ b/src/obj-type.js
@@ -1,8 +1,10 @@
+import { Iterable } from 'immutable';
+
 export default function(obj) {
     if (obj !== null && typeof obj === 'object' && !Array.isArray(obj) &&
         typeof obj[Symbol.iterator] === 'function'
     ) {
-        return 'Iterable';
+        return Iterable.isIterable(obj) ? 'Immutable_Iterable' : 'Iterable';
     }
     return Object.prototype.toString.call(obj).slice(8, -1);
 }


### PR DESCRIPTION
Okay, so this is a bit of a bold move, but as I have mentioned [here](https://github.com/chibicode/react-json-tree/pull/36#issuecomment-189776563), I don't really see why there is a separate node for Iterable objects. Yes, this monitor does show the type of the object in the state, but I think that has limited value. I also think the amount of effort to get this to work with immutable properly would be mammoth (I got some way towards making the JSONDiff module work, when I realised that the whole "pin" feature is incompatible as well.

I think this solution (converting to pure JS) is the cleanest, and provides immediate support for the immutable library without a huge undertaking. If you want to go back and do it properly another time, fair enough, but for now I think this is the right way to go.
