### PR TITLE
Add display of dispatched actions and their payload

### DIFF
--- a/demo/src/js/DemoApp.jsx
+++ b/demo/src/js/DemoApp.jsx
@@ -43,6 +43,7 @@ class DemoApp extends React.Component {
           <Button onClick={this.props.pop} style={styles.button}>Pop</Button>
           <Button onClick={this.props.replace} style={styles.button}>Replace</Button>
           <Button onClick={this.props.nested} style={styles.button}>Change Nested</Button>
+          <Button onClick={this.props.random} style={styles.button}>Random Payload</Button>
         </div>
       </div>
     );
@@ -56,6 +57,7 @@ export default connect(
     push: () => ({ type: 'PUSH' }),
     pop: () => ({ type: 'POP' }),
     replace: () => ({ type: 'REPLACE' }),
-    nested: () => ({ type: 'CHANGE_NESTED' })
+    nested: () => ({ type: 'CHANGE_NESTED' }),
+    random: () => ({ type: 'RANDOM_PAYLOAD', payload: Math.random() })
   }
 )(DemoApp);

--- a/src/ActionPreview.jsx
+++ b/src/ActionPreview.jsx
@@ -67,7 +67,7 @@ function getItemString(createTheme, type, data) {
 }
 
 const ActionPreview = ({
-  theme, defaultTheme, fromState, toState, onInspectPath, inspectedPath, tab, onSelectTab
+  theme, defaultTheme, fromState, toState, onInspectPath, inspectedPath, tab, onSelectTab, action
 }) => {
   const createTheme = themeable({ ...theme, ...defaultTheme });
   const delta = fromState && toState && jsonDiff.diff(
@@ -105,6 +105,15 @@ const ActionPreview = ({
       {tab === 'State' && toState &&
         <JSONTree labelRenderer={labelRenderer}
                   data={getInspectedState(toState.state, inspectedPath)}
+                  getItemString={(type, data) => getItemString(createTheme, type, data)}
+                  getItemStringStyle={
+                    (type, expanded) => ({ display: expanded ? 'none' : 'inline' })
+                  }
+                  hideRoot />
+      }
+      {tab === 'Action' &&
+        <JSONTree labelRenderer={labelRenderer}
+                  data={getInspectedState(action, inspectedPath)}
                   getItemString={(type, data) => getItemString(createTheme, type, data)}
                   getItemStringStyle={
                     (type, expanded) => ({ display: expanded ? 'none' : 'inline' })

--- a/src/ActionPreviewHeader.jsx
+++ b/src/ActionPreviewHeader.jsx
@@ -29,7 +29,7 @@ const ActionPreviewHeader = ({
         )}
       </div>
       <div {...createTheme('tabSelector')}>
-        {['Diff', 'State'].map(t =>
+        {['Action', 'Diff', 'State'].map(t =>
           <div onClick={() => onSelectTab(t)}
                key={t}
                {...createTheme(

--- a/src/DevtoolsInspector.js
+++ b/src/DevtoolsInspector.js
@@ -81,7 +81,8 @@ export default class DevtoolsInspector extends Component {
                        toState={computedStates[currentActionId]}
                        onInspectPath={(path) => this.setState({ inspectedPath: path })}
                        inspectedPath={inspectedPath}
-                       onSelectTab={tab => this.setState({ tab })} />
+                       onSelectTab={tab => this.setState({ tab })}
+                       action={actions[currentActionId].action} />
       </div>
     );
   }

--- a/src/DevtoolsInspector.js
+++ b/src/DevtoolsInspector.js
@@ -11,7 +11,8 @@ export default class DevtoolsInspector extends Component {
     this.state = {
       isWideLayout: false,
       selectedActionId: null,
-      inspectedPath: [],
+      inspectedActionPath: [],
+      inspectedStatePath: [],
       tab: 'Diff'
     };
   }
@@ -59,10 +60,11 @@ export default class DevtoolsInspector extends Component {
 
   render() {
     const { theme, stagedActionIds: actionIds, actionsById: actions, computedStates } = this.props;
-    const { isWideLayout, selectedActionId, inspectedPath, searchValue, tab } = this.state;
+    const { isWideLayout, selectedActionId, searchValue, tab } = this.state;
     const createTheme = themeable({ ...theme, ...defaultTheme });
     const lastActionId = actionIds[actionIds.length - 1];
     const currentActionId = selectedActionId === null ? lastActionId : selectedActionId;
+    const inspectedPathType = tab === 'Action' ? 'inspectedActionPath' : 'inspectedStatePath'
 
     return (
       <div key='inspector'
@@ -79,8 +81,8 @@ export default class DevtoolsInspector extends Component {
                          computedStates[currentActionId - 1] : null
                        }
                        toState={computedStates[currentActionId]}
-                       onInspectPath={(path) => this.setState({ inspectedPath: path })}
-                       inspectedPath={inspectedPath}
+                       onInspectPath={(path) => this.setState({ [inspectedPathType]: path })}
+                       inspectedPath={this.state[inspectedPathType]}
                        onSelectTab={tab => this.setState({ tab })}
                        action={actions[currentActionId].action} />
       </div>


### PR DESCRIPTION
Hi, Thanks for the amazing work on this!

This is a proposal to get a display of dispatched actions. Currently, we can see the diff and state for each action, but not the payload of the action, which could be quite helpful.

The current demo did not really show why someone would need to this display as none of the fired actions had anything but a type, so I added a button able to fire an action fired with a random payload.
