### PR TITLE
Prevent crashes when working with ES2015 symbols

### DIFF
--- a/demo/src/js/DemoApp.jsx
+++ b/demo/src/js/DemoApp.jsx
@@ -109,6 +109,9 @@ class DemoApp extends React.Component {
             <Button onClick={this.props.addFunction} style={styles.button}>
               Add Function
             </Button>
+            <Button onClick={this.props.addSymbol} style={styles.button}>
+              Add Symbol
+            </Button>
           </div>
         </div>
         <div style={styles.links}>
@@ -155,6 +158,7 @@ export default connect(
       type: 'HUGE_PAYLOAD',
       payload: Array.from({ length: 10000 }).map((_, i) => i)
     }),
-    addFunction: () => ({ type: 'ADD_FUNCTION' })
+    addFunction: () => ({ type: 'ADD_FUNCTION' }),
+    addSymbol: () => ({ type: 'ADD_SYMBOL' })
   }
 )(DemoApp);

--- a/demo/src/js/reducers.js
+++ b/demo/src/js/reducers.js
@@ -90,5 +90,7 @@ export default combineReducers({
       str => str + '!'
     ) : state,
   addFunction: (state=null, action) => action.type === 'ADD_FUNCTION' ?
-    { f: FUNC } : state
+    { f: FUNC } : state,
+  addSymbol: (state=null, action) => action.type === 'ADD_SYMBOL' ?
+    { s: Symbol('symbol') } : state
 });

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "babel-runtime": "^6.3.19",
     "dateformat": "^1.0.12",
     "immutable": "^3.7.6",
-    "javascript-stringify": "^1.0.2",
+    "javascript-stringify": "^1.1.0",
     "jsondiffpatch": "^0.1.41",
     "jss": "^3.3.0",
     "jss-nested": "^1.0.2",

--- a/src/ActionPreview.jsx
+++ b/src/ActionPreview.jsx
@@ -30,6 +30,8 @@ function getItemString(createTheme, type, data) {
       return 'fn';
     } else if (typeof val === 'string') {
       return `"${val.substr(0, 10) + (val.length > 10 ? '…' : '')}"`
+    } else if (typeof val === 'symbol') {
+      return 'symbol'
     } else {
       return val;
     }


### PR DESCRIPTION
redux-devtools-inspector crashed when using symbols.

The two following things caused the crashes:
- `javascript-stringify` did not support symbols whereas the previously used `jsan` did. [Here's the PR I sent them to fix this](https://github.com/blakeembrey/javascript-stringify/pull/2) (merged).
- `getShortTypeString` in `ActionPreview.jsx` did not support Symbols, so it tried using them as strings, which is not supported and caused the error `Uncaught TypeError: Cannot convert a Symbol value to a string`

This corrected, there is still a problem as Symbol values are not shown in JSONTree. [Here's the PR I sent for this](https://github.com/chibicode/react-json-tree/pull/39)

I think this is what causes #17, though I'm not sure it is the only cause. I got it while sending a React element in an action payload, and [React elements have a `$$typeof: Symbol.for('react.element')` property](https://facebook.github.io/react/blog/2015/12/18/react-components-elements-and-instances.html)
