### PR TITLE
Allow having empty arrays of actions and states, which is the initial behaviour of the extension

### DIFF
--- a/src/DevtoolsInspector.js
+++ b/src/DevtoolsInspector.js
@@ -16,7 +16,7 @@ function getCurrentActionId(props, state) {
 function createState(props, state) {
   const { supportImmutable, computedStates, actionsById: actions } = props;
   const currentActionId = getCurrentActionId(props, state);
-  const currentAction = actions[currentActionId].action;
+  const currentAction = actions[currentActionId] && actions[currentActionId].action;
 
   const fromState = currentActionId > 0 ? computedStates[currentActionId - 1] : null;
   const toState = computedStates[currentActionId];
@@ -24,7 +24,7 @@ function createState(props, state) {
   const fromInspectedState = fromState &&
     getInspectedState(fromState.state, state.inspectedStatePath, supportImmutable);
   const toInspectedState =
-    getInspectedState(toState.state, state.inspectedStatePath, supportImmutable);
+    toState && getInspectedState(toState.state, state.inspectedStatePath, supportImmutable);
   const delta = fromState && toState && DiffPatcher.diff(
     fromInspectedState,
     toInspectedState
@@ -33,7 +33,7 @@ function createState(props, state) {
   return {
     delta,
     currentActionId,
-    nextState: getInspectedState(toState.state, state.inspectedStatePath, false),
+    nextState: toState && getInspectedState(toState.state, state.inspectedStatePath, false),
     action: getInspectedState(currentAction, state.inspectedActionPath, false)
   };
 }


### PR DESCRIPTION
After https://github.com/zalmoxisus/redux-devtools-extension/pull/72, these arrays are always empty when first opening the monitor.
