### PR TITLE
Get computed state by action index

### DIFF
--- a/src/DevtoolsInspector.js
+++ b/src/DevtoolsInspector.js
@@ -18,8 +18,9 @@ function createState(props, state) {
   const currentActionId = getCurrentActionId(props, state);
   const currentAction = actions[currentActionId] && actions[currentActionId].action;
 
-  const fromState = currentActionId > 0 ? computedStates[currentActionId - 1] : null;
-  const toState = computedStates[currentActionId];
+  const actionIndex = Object.keys(actions).indexOf(currentActionId && currentActionId.toString());
+  const fromState = actionIndex > 0 ? computedStates[actionIndex - 1] : null;
+  const toState = computedStates[actionIndex];
 
   const fromInspectedState = fromState &&
     getInspectedState(fromState.state, state.inspectedStatePath, supportImmutable);


### PR DESCRIPTION
I'm working to add `inspector` to `remotedev-app` (https://github.com/zalmoxisus/remotedev-app/pull/3), due to some reasons ([1](https://github.com/zalmoxisus/remotedev-app/pull/3#issuecomment-205653450) & [2](https://github.com/zalmoxisus/remotedev-app/pull/3#issuecomment-205716863)), the length of `actionsById` not matched `computedStates` in some case.
