### PR TITLE
Use stagedActionIds instead of Object.keys(actionsById)

### DIFF
--- a/src/DevtoolsInspector.js
+++ b/src/DevtoolsInspector.js
@@ -14,11 +14,11 @@ function getCurrentActionId(props, state) {
 }
 
 function createState(props, state) {
-  const { supportImmutable, computedStates, actionsById: actions } = props;
+  const { supportImmutable, computedStates, stagedActionIds, actionsById: actions } = props;
   const currentActionId = getCurrentActionId(props, state);
   const currentAction = actions[currentActionId] && actions[currentActionId].action;
 
-  const actionIndex = Object.keys(actions).indexOf(currentActionId && currentActionId.toString());
+  const actionIndex = stagedActionIds.indexOf(currentActionId);
   const fromState = actionIndex > 0 ? computedStates[actionIndex - 1] : null;
   const toState = computedStates[actionIndex];
 


### PR DESCRIPTION
`Object.keys(actionsById)` does not always have exact same order with `computedStates`.

For example when blacklist or whitelist is applied to actions (like [in the chrome extension](https://github.com/zalmoxisus/redux-devtools-extension/blob/63626c431f3e20d016885079b61861598763477b/src/browser/extension/inject/pageScript.js#L101-L115)), `Object.keys(actionsById)` will be a bigger array than `computedStates`, because it is not filtered.
