### PR TITLE
Show reducers errors

### DIFF
--- a/src/ActionPreview.jsx
+++ b/src/ActionPreview.jsx
@@ -64,7 +64,7 @@ function getItemString(createTheme, type, data) {
 class ActionPreview extends Component {
   render() {
     const {
-      styling, delta, nextState, onInspectPath, inspectedPath, tab,
+      styling, delta, error, nextState, onInspectPath, inspectedPath, tab,
       onSelectTab, action, base16Theme, isLightTheme
     } = this.props;
 
@@ -73,11 +73,11 @@ class ActionPreview extends Component {
         <ActionPreviewHeader {...{
           styling, inspectedPath, onInspectPath, tab, onSelectTab
         }} />
-        {tab === 'Diff' &&
+        {tab === 'Diff' && !error &&
           <JSONDiff labelRenderer={this.labelRenderer}
                     {...{ delta, styling, base16Theme, isLightTheme }} />
         }
-        {(tab === 'State' && nextState || tab === 'Action') &&
+        {(tab === 'State' && nextState && !error || tab === 'Action') &&
           <JSONTree labelRenderer={this.labelRenderer}
                     theme={{
                       extend: base16Theme,
@@ -92,6 +92,9 @@ class ActionPreview extends Component {
                     getItemString={(type, data) => getItemString(styling, type, data)}
                     isLightTheme={isLightTheme}
                     hideRoot />
+        }
+        {error &&
+          <div {...styling('stateError')}>{error}</div>
         }
       </div>
     );

--- a/src/DevtoolsInspector.js
+++ b/src/DevtoolsInspector.js
@@ -32,12 +32,13 @@ function createMonitorState(props, monitorState) {
   const actionIndex = stagedActionIds.indexOf(currentActionId);
   const fromState = actionIndex > 0 ? computedStates[actionIndex - 1] : null;
   const toState = computedStates[actionIndex];
+  const { error } = toState;
 
-  const fromInspectedState = fromState &&
+  const fromInspectedState = !error && fromState &&
     getInspectedState(fromState.state, inspectedStatePath, supportImmutable);
   const toInspectedState =
-    toState && getInspectedState(toState.state, inspectedStatePath, supportImmutable);
-  const delta = fromState && toState && DiffPatcher.diff(
+    !error && toState && getInspectedState(toState.state, inspectedStatePath, supportImmutable);
+  const delta = !error && fromState && toState && DiffPatcher.diff(
     fromInspectedState,
     toInspectedState
   );
@@ -47,7 +48,8 @@ function createMonitorState(props, monitorState) {
     delta,
     currentActionId,
     nextState: toState && getInspectedState(toState.state, inspectedStatePath, false),
-    action: getInspectedState(currentAction, inspectedActionPath, false)
+    action: getInspectedState(currentAction, inspectedActionPath, false),
+    error
   };
 }
 
@@ -169,7 +171,7 @@ export default class DevtoolsInspector extends Component {
             isLightTheme, skippedActionIds } = this.props;
     const { monitorState } = this.state;
     const { isWideLayout, selectedActionId, nextState, action,
-            searchValue, tab, delta } = monitorState;
+            searchValue, tab, delta, error } = monitorState;
     const inspectedPathType = tab === 'Action' ? 'inspectedActionPath' : 'inspectedStatePath';
     const { base16Theme, styling } = this.state.themeState;
 
@@ -186,7 +188,7 @@ export default class DevtoolsInspector extends Component {
                     onSweep={this.handleSweep}
                     skippedActionIds={skippedActionIds}
                     lastActionId={getLastActionId(this.props)} />
-        <ActionPreview {...{ base16Theme, tab, delta, nextState, action, isLightTheme }}
+        <ActionPreview {...{ base16Theme, tab, delta, error, nextState, action, isLightTheme }}
                        styling={styling}
                        onInspectPath={this.handleInspectPath.bind(this, inspectedPathType)}
                        inspectedPath={monitorState[inspectedPathType]}

--- a/src/createStylingFromTheme.js
+++ b/src/createStylingFromTheme.js
@@ -31,7 +31,8 @@ const colorMap = theme => ({
   DIFF_REMOVE_COLOR: rgba(theme.base08, 40),
   DIFF_ARROW_COLOR: theme.base0E,
   LINK_COLOR: rgba(theme.base0E, 90),
-  LINK_HOVER_COLOR: theme.base0E
+  LINK_HOVER_COLOR: theme.base0E,
+  ERROR_COLOR: theme.base08,
 });
 
 const getSheetFromColorMap = map => ({
@@ -196,6 +197,14 @@ const getSheetFromColorMap = map => ({
     padding: '10px',
 
     color: map.TEXT_PLACEHOLDER_COLOR
+  },
+
+  stateError: {
+    padding: '10px',
+    'margin-left': '14px',
+    'font-weight': 'bold',
+
+    color: map.ERROR_COLOR
   },
 
   inspectedPath: {


### PR DESCRIPTION
Similarly to `logMonitor`, show when there are errors in reducers (caught in [devtools' instrumentation](https://github.com/zalmoxisus/redux-devtools-instrument/blob/master/src/instrument.js#L87-L98)).

To check how it works, change

``` js
store: (state=0, action) => action.type === 'INCREMENT' ? state + 1 : state,
```

to

``` js
store: (state=0, action) => action.type === 'INCREMENT' ? state1 + 1 : state,
```

in [demo/src/js/reducers.js#L52](https://github.com/alexkuz/redux-devtools-inspector/blob/master/demo/src/js/reducers.js#L52) and try to increment.
