### PR TITLE
Fix actionListHeader layout

### DIFF
--- a/src/createStylingFromTheme.js
+++ b/src/createStylingFromTheme.js
@@ -69,7 +69,6 @@ const getSheetFromColorMap = map => ({
 
   actionListHeader: {
     display: 'flex',
-    flex: '0 0',
     'align-items': 'center',
     'border-bottom-width': '1px',
     'border-bottom-style': 'solid',


### PR DESCRIPTION
This is actionListHeader layout in Chrome 51:

![2016-05-27 10 35 43](https://cloud.githubusercontent.com/assets/3001525/15611267/30e00144-245c-11e6-83ba-b7d8e676785a.png)
