### PR TITLE
Fix filter height

### DIFF
--- a/src/createStylingFromTheme.js
+++ b/src/createStylingFromTheme.js
@@ -69,6 +69,7 @@ const getSheetFromColorMap = map => ({
 
   actionListHeader: {
     display: 'flex',
+    flex: '0 0 auto',
     'align-items': 'center',
     'border-bottom-width': '1px',
     'border-bottom-style': 'solid',


### PR DESCRIPTION
Add `div` around the filter to breaks it out of the `flexbox` position/size.  This lets it keep a static size.
