### PR TITLE
Implement support for custom tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Name               | Type             | Description
 ------------------ | ---------------- | -------------
 `theme`            | Object or string | Contains either [base16](https://github.com/chriskempson/base16) theme name or object, that can be `base16` colors map or object containing classnames or styles.
 `supportImmutable` | Boolean          | Better `Immutable` rendering in `Diff` (can affect performance if state has huge objects/arrays). `false` by default.
+`customTabs`       | Array            | Add custom tabs with specified React components to inspect selected actions, for example [`redux-devtools-test-generator`](https://github.com/zalmoxisus/redux-devtools-test-generator#containersdevtoolsjs).
 
 ### License
 

--- a/src/ActionPreview.jsx
+++ b/src/ActionPreview.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, cloneElement } from 'react';
 import JSONTree from 'react-json-tree';
 import ActionPreviewHeader from './ActionPreviewHeader';
 import JSONDiff from './JSONDiff';
@@ -65,13 +65,14 @@ class ActionPreview extends Component {
   render() {
     const {
       styling, delta, error, nextState, onInspectPath, inspectedPath, tab,
-      onSelectTab, action, base16Theme, isLightTheme
+      onSelectTab, action, actions, selectedActionId, startActionId,
+      computedStates, base16Theme, isLightTheme, customTabs
     } = this.props;
 
     return (
       <div key='actionPreview' {...styling('actionPreview')}>
         <ActionPreviewHeader {...{
-          styling, inspectedPath, onInspectPath, tab, onSelectTab
+          styling, inspectedPath, onInspectPath, tab, onSelectTab, customTabs
         }} />
         {tab === 'Diff' && !error &&
           <JSONDiff labelRenderer={this.labelRenderer}
@@ -92,6 +93,11 @@ class ActionPreview extends Component {
                     getItemString={(type, data) => getItemString(styling, type, data)}
                     isLightTheme={isLightTheme}
                     hideRoot />
+        }
+        {customTabs && customTabs[tab] &&
+          cloneElement(customTabs[tab],
+            {...{styling, computedStates, actions, selectedActionId, startActionId}}
+          )
         }
         {error &&
           <div {...styling('stateError')}>{error}</div>

--- a/src/ActionPreview.jsx
+++ b/src/ActionPreview.jsx
@@ -64,7 +64,7 @@ function getItemString(createTheme, type, data) {
 class ActionPreview extends Component {
   render() {
     const {
-      styling, delta, error, nextState, onInspectPath, inspectedPath, tab,
+      styling, delta, error, nextState, onInspectPath, inspectedPath, tab, tabIdx,
       onSelectTab, action, actions, selectedActionId, startActionId,
       computedStates, base16Theme, isLightTheme, customTabs
     } = this.props;
@@ -72,7 +72,7 @@ class ActionPreview extends Component {
     return (
       <div key='actionPreview' {...styling('actionPreview')}>
         <ActionPreviewHeader {...{
-          styling, inspectedPath, onInspectPath, tab, onSelectTab, customTabs
+          styling, inspectedPath, onInspectPath, tab, tabIdx, onSelectTab, customTabs
         }} />
         {tab === 'Diff' && !error &&
           <JSONDiff labelRenderer={this.labelRenderer}
@@ -94,8 +94,8 @@ class ActionPreview extends Component {
                     isLightTheme={isLightTheme}
                     hideRoot />
         }
-        {customTabs && customTabs[tab] &&
-          cloneElement(customTabs[tab],
+        {customTabs && tabIdx > 2 &&
+          cloneElement(customTabs[tabIdx - 3].component,
             {...{styling, computedStates, actions, selectedActionId, startActionId}}
           )
         }

--- a/src/ActionPreviewHeader.jsx
+++ b/src/ActionPreviewHeader.jsx
@@ -1,46 +1,55 @@
-import React from 'react';
+import React, { Component } from 'react';
 
-const ActionPreviewHeader = ({
-  styling, inspectedPath, onInspectPath, tab, onSelectTab, customTabs
-}) => {
-  let tabs = ['Action', 'Diff', 'State'];
-  if (customTabs) tabs = tabs.concat(Object.keys(customTabs));
-  return (
-    <div key='previewHeader' {...styling('previewHeader')}>
-      <div {...styling('tabSelector')}>
-        {tabs.map(t =>
-          <div onClick={() => onSelectTab(t)}
-               key={t}
-               {...styling([
-                 'selectorButton',
-                 t === tab && 'selectorButtonSelected'
-               ], t === tab)}>
-            {t}
-          </div>
-        )}
+class ActionPreviewHeader extends Component {
+  constructor(props) {
+    super(props);
+    this.tabs = ['Action', 'Diff', 'State'];
+    if (props.customTabs) {
+      props.customTabs.forEach(tab => {
+        this.tabs.push(tab.name);
+      });
+    }
+  }
+
+  render() {
+    const {styling, inspectedPath, onInspectPath, tab, tabIdx, onSelectTab} = this.props;
+    return (
+      <div key='previewHeader' {...styling('previewHeader')}>
+        <div {...styling('tabSelector')}>
+          {this.tabs.map((t, i) =>
+            <div onClick={() => onSelectTab(t, i)}
+                 key={i}
+              {...styling([
+                'selectorButton',
+                i === tabIdx && 'selectorButtonSelected'
+              ], i === tabIdx)}>
+              {t}
+            </div>
+          )}
+        </div>
+        <div {...styling('inspectedPath')}>
+          {inspectedPath.length ?
+            <span {...styling('inspectedPathKey')}>
+              <a onClick={() => onInspectPath([])}
+                {...styling('inspectedPathKeyLink')}>
+                {tab}
+              </a>
+            </span> : tab
+          }
+          {inspectedPath.map((key, idx) =>
+            idx === inspectedPath.length - 1 ? key :
+              <span key={key}
+                {...styling('inspectedPathKey')}>
+              <a onClick={() => onInspectPath(inspectedPath.slice(0, idx + 1))}
+                {...styling('inspectedPathKeyLink')}>
+                {key}
+              </a>
+            </span>
+          )}
+        </div>
       </div>
-      <div {...styling('inspectedPath')}>
-        {inspectedPath.length ?
-          <span {...styling('inspectedPathKey')}>
-            <a onClick={() => onInspectPath([])}
-               {...styling('inspectedPathKeyLink')}>
-              {tab}
-            </a>
-          </span> : tab
-        }
-        {inspectedPath.map((key, idx) =>
-          idx === inspectedPath.length - 1 ? key :
-          <span key={key}
-             {...styling('inspectedPathKey')}>
-            <a onClick={() => onInspectPath(inspectedPath.slice(0, idx + 1))}
-               {...styling('inspectedPathKeyLink')}>
-              {key}
-            </a>
-          </span>
-        )}
-      </div>
-    </div>
-  );
+    );
+  }
 }
 
 export default ActionPreviewHeader;

--- a/src/ActionPreviewHeader.jsx
+++ b/src/ActionPreviewHeader.jsx
@@ -1,12 +1,14 @@
 import React from 'react';
 
 const ActionPreviewHeader = ({
-  styling, inspectedPath, onInspectPath, tab, onSelectTab
+  styling, inspectedPath, onInspectPath, tab, onSelectTab, customTabs
 }) => {
+  let tabs = ['Action', 'Diff', 'State'];
+  if (customTabs) tabs = tabs.concat(Object.keys(customTabs));
   return (
     <div key='previewHeader' {...styling('previewHeader')}>
       <div {...styling('tabSelector')}>
-        {['Action', 'Diff', 'State'].map(t =>
+        {tabs.map(t =>
           <div onClick={() => onSelectTab(t)}
                key={t}
                {...styling([

--- a/src/ActionPreviewHeader.jsx
+++ b/src/ActionPreviewHeader.jsx
@@ -3,12 +3,23 @@ import React, { Component } from 'react';
 class ActionPreviewHeader extends Component {
   constructor(props) {
     super(props);
-    this.tabs = ['Action', 'Diff', 'State'];
-    if (props.customTabs) {
-      props.customTabs.forEach(tab => {
-        this.tabs.push(tab.name);
+    this.state = { tabs: this.getTabs(props.customTabs) };
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.customTabs !== this.props.customTabs) {
+      this.setState({ tabs: this.getTabs(props.customTabs) });
+    }
+  }
+
+  getTabs(customTabs) {
+    const tabs = ['Action', 'Diff', 'State'];
+    if (customTabs) {
+      customTabs.forEach(tab => {
+        tabs.push(tab.name);
       });
     }
+    return tabs;
   }
 
   render() {
@@ -16,7 +27,7 @@ class ActionPreviewHeader extends Component {
     return (
       <div key='previewHeader' {...styling('previewHeader')}>
         <div {...styling('tabSelector')}>
-          {this.tabs.map((t, i) =>
+          {this.state.tabs.map((t, i) =>
             <div onClick={() => onSelectTab(t, i)}
                  key={i}
               {...styling([

--- a/src/DevtoolsInspector.js
+++ b/src/DevtoolsInspector.js
@@ -74,6 +74,7 @@ function createThemeState(props) {
 const DEFAULT_MONITOR_STATE = {
   isWideLayout: false,
   tab: 'Diff',
+  tabIdx: 1,
   inspectedStatePath: [],
   inspectedActionPath: [],
   startActionId: null,
@@ -183,7 +184,7 @@ export default class DevtoolsInspector extends Component {
       customTabs, isLightTheme, skippedActionIds } = this.props;
     const { monitorState } = this.state;
     const { isWideLayout, selectedActionId, startActionId, nextState, action,
-            searchValue, tab, delta, error } = monitorState;
+            searchValue, tab, tabIdx, delta, error } = monitorState;
     const inspectedPathType = tab === 'Action' ? 'inspectedActionPath' : 'inspectedStatePath';
     const { base16Theme, styling } = this.state.themeState;
 
@@ -203,7 +204,7 @@ export default class DevtoolsInspector extends Component {
                     skippedActionIds={skippedActionIds}
                     lastActionId={getLastActionId(this.props)} />
         <ActionPreview {...{
-          base16Theme, isLightTheme, customTabs, tab, delta, error, nextState,
+          base16Theme, isLightTheme, customTabs, tab, tabIdx, delta, error, nextState,
           computedStates, action, actions, selectedActionId, startActionId
         }}
                        styling={styling}
@@ -264,7 +265,7 @@ export default class DevtoolsInspector extends Component {
     this.updateMonitorState({ [pathType]: path });
   };
 
-  handleSelectTab = tab => {
-    this.updateMonitorState({ tab });
+  handleSelectTab = (tab, tabIdx) => {
+    this.updateMonitorState({ tab, tabIdx });
   };
 }

--- a/src/DevtoolsInspector.js
+++ b/src/DevtoolsInspector.js
@@ -179,8 +179,8 @@ export default class DevtoolsInspector extends Component {
   }
 
   render() {
-    const { stagedActionIds: actionIds, actionsById: actions,
-            isLightTheme, skippedActionIds } = this.props;
+    const { stagedActionIds: actionIds, actionsById: actions, computedStates,
+      customTabs, isLightTheme, skippedActionIds } = this.props;
     const { monitorState } = this.state;
     const { isWideLayout, selectedActionId, startActionId, nextState, action,
             searchValue, tab, delta, error } = monitorState;
@@ -202,7 +202,10 @@ export default class DevtoolsInspector extends Component {
                     onSweep={this.handleSweep}
                     skippedActionIds={skippedActionIds}
                     lastActionId={getLastActionId(this.props)} />
-        <ActionPreview {...{ base16Theme, tab, delta, error, nextState, action, isLightTheme }}
+        <ActionPreview {...{
+          base16Theme, isLightTheme, customTabs, tab, delta, error, nextState,
+          computedStates, action, actions, selectedActionId, startActionId
+        }}
                        styling={styling}
                        onInspectPath={this.handleInspectPath.bind(this, inspectedPathType)}
                        inspectedPath={monitorState[inspectedPathType]}

--- a/src/redux.js
+++ b/src/redux.js
@@ -7,6 +7,7 @@ const DEFAULT_STATE = {
   inspectedActionPath: [],
   inspectedStatePath: [],
   tab: 'Diff',
+  tabIdx: 1,
   isLightTheme: true,
   styling: () => ({})
 };


### PR DESCRIPTION
As per https://github.com/alexkuz/redux-devtools-inspector/pull/31#issuecomment-226203139, it will be possible to specify add tabs for custom React components to inspect selected actions as bellow:

``` jsx
<InspectorMonitor 
   customTabs = {{
      'MyInspect': <MyInspectComponent />
   }}
/>
```

Use with [`redux-devtools-test-generator`](https://github.com/zalmoxisus/redux-devtools-test-generator) to generate tests for specific actions.
