### PR TITLE
Prevent crashing browser for circular references

### DIFF
--- a/demo/src/js/reducers.js
+++ b/demo/src/js/reducers.js
@@ -34,8 +34,11 @@ const HUGE_OBJECT = Array.from({ length: 5000 })
 
 const FUNC = function (a, b, c) { return a + b + c; };
 
-const RECURSIVE = {};
-RECURSIVE.obj = RECURSIVE;
+function addRecursive() {
+  const RECURSIVE = {};
+  RECURSIVE.obj = RECURSIVE;
+  return RECURSIVE;
+}
 
 function createIterator() {
   const iterable = {};
@@ -79,8 +82,8 @@ export default {
           }]
         }
       } : state,
-  recursive: (state=[], action) => action.type === 'ADD_RECURSIVE' ?
-    [...state, { ...RECURSIVE }] : state,
+  recursive: (state={}, action) => action.type === 'ADD_RECURSIVE' ?
+    {...state, a: addRecursive() } : state,
   immutables: (state=[], action) => action.type === 'ADD_IMMUTABLE_MAP' ?
     [...state, IMMUTABLE_MAP] : state,
   immutableNested: (state=IMMUTABLE_NESTED, action) => action.type === 'CHANGE_IMMUTABLE_NESTED' ?

--- a/src/DiffPatcher.js
+++ b/src/DiffPatcher.js
@@ -1,11 +1,27 @@
 import { DiffPatcher } from 'jsondiffpatch/src/diffpatcher';
 
+const isLoop = function(context) {
+  // Based on https://github.com/benjamine/jsondiffpatch/issues/152
+  let i=0;
+  let parent = context.parent;
+  while (parent !== undefined) {
+    if (parent.left === context.left && parent.right === context.right) {
+      return true;
+    }
+    parent = parent.parent;
+    i++;
+    if (i>10) return false; // We don't want to go that deep
+  }
+  return false;
+};
+
 const diffpatcher = new DiffPatcher({
   arrays: { detectMove: false },
   objectHash: (o, idx) => o.hasOwnProperty('id') ? o.id : '$$index:' + idx,
   propertyFilter: (name, context) =>
     typeof context.left[name] !== 'function' &&
-    typeof context.right[name] !== 'function'
+    typeof context.right[name] !== 'function' &&
+    !isLoop(context)
 });
 
 export default diffpatcher;


### PR DESCRIPTION
According to https://github.com/benjamine/jsondiffpatch/issues/152, if there's circular reference in both sides of the diff, we'll have an infinite loop, which will hang and crash the browser. To reproduce it, remove `notCircular` function I've introduced in `DiffPatcher.js` and on the demo page click `ADD RECURSIVE` button two times.
