### PR TITLE
Fix `hasOwnProperty` method of `undefined` exception

### DIFF
--- a/src/DiffPatcher.js
+++ b/src/DiffPatcher.js
@@ -2,7 +2,8 @@ import { DiffPatcher } from 'jsondiffpatch/src/diffpatcher';
 
 const diffpatcher = new DiffPatcher({
   arrays: { detectMove: false },
-  objectHash: (o, idx) => o.hasOwnProperty('id') ? o.id : '$$index:' + idx,
+  objectHash: (o, idx) =>
+    typeof o === 'object' && o.hasOwnProperty('id') ? o.id : '$$index:' + idx,
   propertyFilter: (name, context) =>
     typeof context.left[name] !== 'function' &&
     typeof context.right[name] !== 'function'


### PR DESCRIPTION
For some reason `DiffPatcher`'s argument can be not only object (probably when comparing an object with something else), which breaks the app.
