### PR TITLE
Fixed action preview header on the top

### DIFF
--- a/demo/src/js/index.js
+++ b/demo/src/js/index.js
@@ -19,6 +19,7 @@ const CustomComponent = () =>
     alignItems: 'center',
     justifyContent: 'center',
     width: '100%',
+    height: '100%',
     minHeight: '20rem'
   }}>
     <div>Custom Tab Content</div>

--- a/src/utils/createStylingFromTheme.js
+++ b/src/utils/createStylingFromTheme.js
@@ -180,8 +180,10 @@ const getSheetFromColorMap = map => ({
   },
 
   actionPreview: {
+    display: 'flex',
+    'flex-direction': 'column',
     'flex-grow': 1,
-    'overflow-y': 'auto',
+    'overflow-y': 'hidden',
 
     '& pre': {
       border: 'inherit',
@@ -191,6 +193,11 @@ const getSheetFromColorMap = map => ({
     },
 
     'background-color': map.BACKGROUND_COLOR,
+  },
+
+  actionPreviewContent: {
+    flex: 1,
+    'overflow-y': 'auto'
   },
 
   stateDiff: {
@@ -249,11 +256,11 @@ const getSheetFromColorMap = map => ({
   },
 
   previewHeader: {
+    flex: '0 0 30px',
     padding: '5px 10px',
     'align-items': 'center',
     'border-bottom-width': '1px',
     'border-bottom-style': 'solid',
-    'min-height': '30px',
 
     'background-color': map.HEADER_BACKGROUND_COLOR,
     'border-bottom-color': map.HEADER_BORDER_COLOR
@@ -263,8 +270,7 @@ const getSheetFromColorMap = map => ({
     position: 'relative',
     'z-index': 1,
     display: 'inline-flex',
-    float: 'right',
-    'margin-bottom': '5px'
+    float: 'right'
   },
 
   selectorButton: {

--- a/src/utils/createStylingFromTheme.js
+++ b/src/utils/createStylingFromTheme.js
@@ -180,6 +180,7 @@ const getSheetFromColorMap = map => ({
   },
 
   actionPreview: {
+    flex: 1,
     display: 'flex',
     'flex-direction': 'column',
     'flex-grow': 1,


### PR DESCRIPTION
Currently we cannot set correctly `height: 100%` to custom tab content height:

![2016-10-15 6 13 03](https://cloud.githubusercontent.com/assets/3001525/19409323/26964894-9304-11e6-8241-f69eabf0d185.png)

Set `flex: 1` to `actionPreview` style will succeed:

![2016-10-15 6 13 54](https://cloud.githubusercontent.com/assets/3001525/19409325/3115003a-9304-11e6-8882-bc4f90d2f769.png)
