### PR TITLE
replace react dom import with actual module

### DIFF
--- a/src/ActionList.jsx
+++ b/src/ActionList.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import ReactDOM from 'react/lib/ReactDOM';
+import ReactDOM from 'react-dom';
 import ActionListRow from './ActionListRow';
 import ActionListHeader from './ActionListHeader';
 import shouldPureComponentUpdate from 'react-pure-render/function';


### PR DESCRIPTION
The new version of React removes `ReactDOM` from the `react` project and moves it into its own module.  This PR fixes an import error for people that are upgraded to the new version of react.

https://facebook.github.io/react/blog/2016/11/16/react-v15.4.0.html

