### PR TITLE
Custom subtabs

### DIFF
--- a/demo/src/js/index.js
+++ b/demo/src/js/index.js
@@ -18,16 +18,19 @@ function getDebugSessionKey() {
   return (matches && matches.length > 0)? matches[1] : null;
 }
 
-const CustomComponent = () =>
+const CustomComponent = ({ data }) =>
   <div style={{
     display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
     width: '100%',
     height: '100%',
     minHeight: '20rem'
   }}>
-    <div>Custom Tab Content</div>
+    <pre style={{
+      flexGrow: '1',
+      margin: '0'
+    }}>
+      {JSON.stringify(data, null, '\t')}
+    </pre>
   </div>;
 
 const getDevTools = options =>
@@ -42,7 +45,19 @@ const getDevTools = options =>
                          supportImmutable={options.supportImmutable}
                          tabs={defaultTabs => [{
                            name: 'Custom Tab',
-                           component: CustomComponent
+                           // component: CustomComponent
+                           components: [
+                             {
+                               name: 'Action as JSON',
+                               component: CustomComponent,
+                               selector: ({ action }) => ({ data: action })
+                             },
+                             {
+                               name: 'State as JSON',
+                               component: CustomComponent,
+                               selector: ({ nextState }) => ({ data: nextState })
+                             }
+                           ]
                          }, ...defaultTabs]} />
     </DockMonitor>
   );

--- a/src/ActionPreview.jsx
+++ b/src/ActionPreview.jsx
@@ -52,11 +52,12 @@ class ActionPreview extends Component {
     let actionPreviewContent;
     if (!error) {
       if (components) {
-        let SubTabComponent = components[0].component;
+        let component;
         const subTabs = components.map(c => {
-          if (c.name === subTabName) SubTabComponent = c.component;
+          if (c.name === subTabName) component = c;
           return c.name;
         });
+        const { component: SubTabComponent, selector } = component || components[0];
         actionPreviewContent = [
           <ActionPreviewSubHeader
             key='actionPreviewSubHeader'
@@ -64,7 +65,7 @@ class ActionPreview extends Component {
             {...{ styling, tabName: subTabName, onSelectTab: onSelectSubTab }}
           />,
           <div key='actionPreviewContent' {...styling('actionPreviewContent')}>
-            <SubTabComponent {...tabProps} />
+            <SubTabComponent {...(selector ? selector(tabProps) : tabProps)} />
           </div>
         ];
       } else {

--- a/src/ActionPreview.jsx
+++ b/src/ActionPreview.jsx
@@ -13,12 +13,7 @@ const DEFAULT_TABS = [{
   component: DiffTab
 }, {
   name: 'State',
-  components: [
-    {
-      name: 'Tree',
-      component: StateTab
-    }
-  ]
+  component: StateTab
 }];
 
 class ActionPreview extends Component {

--- a/src/ActionPreviewSubHeader.jsx
+++ b/src/ActionPreviewSubHeader.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+const ActionPreviewSubHeader =
+  ({ styling, tabName, onSelectTab, tabs }) =>
+    <div key='previewSubHeader' {...styling('previewSubHeader')}>
+      <div {...styling('subTabSelector')}>
+        {tabs.map(tab =>
+          <div onClick={() => onSelectTab(tab)}
+               key={tab}
+               {...styling([
+                 'selectorButton',
+                 tab === tabName && 'selectorButtonSelected'
+               ], tab === tabName)}>
+            {tab}
+          </div>
+        )}
+      </div>
+    </div>;
+
+export default ActionPreviewSubHeader;

--- a/src/DevtoolsInspector.js
+++ b/src/DevtoolsInspector.js
@@ -150,7 +150,7 @@ export default class DevtoolsInspector extends Component {
   render() {
     const { stagedActionIds: actionIds, actionsById: actions, computedStates,
       tabs, invertTheme, skippedActionIds, monitorState } = this.props;
-    const { selectedActionId, startActionId, searchValue, tabName } = monitorState;
+    const { selectedActionId, startActionId, searchValue, tabName, subTabName } = monitorState;
     const inspectedPathType = tabName === 'Action' ? 'inspectedActionPath' : 'inspectedStatePath';
     const { themeState, isWideLayout, action, nextState, delta, error } = this.state;
     const { base16Theme, styling } = themeState;
@@ -171,13 +171,14 @@ export default class DevtoolsInspector extends Component {
                     skippedActionIds={skippedActionIds}
                     lastActionId={getLastActionId(this.props)} />
         <ActionPreview {...{
-          base16Theme, invertTheme, tabs, tabName, delta, error, nextState,
+          base16Theme, invertTheme, tabs, subTabName, tabName, delta, error, nextState,
           computedStates, action, actions, selectedActionId, startActionId
         }}
                        styling={styling}
                        onInspectPath={this.handleInspectPath.bind(this, inspectedPathType)}
                        inspectedPath={monitorState[inspectedPathType]}
-                       onSelectTab={this.handleSelectTab} />
+                       onSelectTab={this.handleSelectTab}
+                       onSelectSubTab={this.handleSelectSubTab}/>
       </div>
     );
   }
@@ -234,5 +235,9 @@ export default class DevtoolsInspector extends Component {
 
   handleSelectTab = tabName => {
     this.updateMonitorState({ tabName });
+  };
+
+  handleSelectSubTab = subTabName => {
+    this.updateMonitorState({ subTabName });
   };
 }

--- a/src/redux.js
+++ b/src/redux.js
@@ -6,7 +6,7 @@ const DEFAULT_STATE = {
   inspectedActionPath: [],
   inspectedStatePath: [],
   tabName: 'Diff',
-  subTabName: 'Tree'
+  subTabName: null
 };
 
 export function updateMonitorState(monitorState) {

--- a/src/redux.js
+++ b/src/redux.js
@@ -5,7 +5,8 @@ const DEFAULT_STATE = {
   startActionId: null,
   inspectedActionPath: [],
   inspectedStatePath: [],
-  tabName: 'Diff'
+  tabName: 'Diff',
+  subTabName: 'Tree'
 };
 
 export function updateMonitorState(monitorState) {

--- a/src/utils/createStylingFromTheme.js
+++ b/src/utils/createStylingFromTheme.js
@@ -18,6 +18,7 @@ const colorMap = theme => ({
   SELECTED_BACKGROUND_COLOR: rgba(theme.base03, 20),
   SKIPPED_BACKGROUND_COLOR: rgba(theme.base03, 10),
   HEADER_BACKGROUND_COLOR: rgba(theme.base03, 30),
+  SUBHEADER_BACKGROUND_COLOR: rgba(theme.base03, 15),
   HEADER_BORDER_COLOR: rgba(theme.base03, 20),
   BORDER_COLOR: rgba(theme.base03, 50),
   LIST_BORDER_COLOR: rgba(theme.base03, 50),
@@ -267,11 +268,28 @@ const getSheetFromColorMap = map => ({
     'border-bottom-color': map.HEADER_BORDER_COLOR
   },
 
+  previewSubHeader: {
+    flex: '0 0 30px',
+    padding: '5px 10px',
+    'align-items': 'center',
+    'border-bottom-width': '1px',
+    'border-bottom-style': 'solid',
+
+    'background-color': map.SUBHEADER_BACKGROUND_COLOR,
+    'border-bottom-color': map.HEADER_BORDER_COLOR
+  },
+
   tabSelector: {
     position: 'relative',
     'z-index': 1,
     display: 'inline-flex',
     float: 'right'
+  },
+
+  subTabSelector: {
+    position: 'relative',
+    'z-index': 1,
+    display: 'inline-flex',
   },
 
   selectorButton: {


### PR DESCRIPTION
In addition to custom tabs, now it's possible to specify custom subtabs with selectors as following:
```jsx
<DevtoolsInspector
                         tabs={defaultTabs => [{
                           name: 'Custom Tab',
                           components: [
                             {
                               name: 'Action as JSON',
                               component: CustomComponent,
                               selector: ({ action }) => ({ data: action })
                             },
                             {
                               name: 'State as JSON',
                               component: CustomComponent,
                               selector: ({ nextState }) => ({ data: nextState })
                             }
                           ]
                         }, ...defaultTabs]} />
```

Which gives:
<img width="1438" alt="screen shot 2016-11-19 at 2 07 21 pm" src="https://cloud.githubusercontent.com/assets/7957859/20455323/d9bbd2f4-ae61-11e6-8c8b-5f9575fd3847.png">
