### PR TITLE
Fix tab component find for ActionPreview

### DIFF
--- a/src/ActionPreview.jsx
+++ b/src/ActionPreview.jsx
@@ -16,6 +16,10 @@ const DEFAULT_TABS = [{
 }]
 
 class ActionPreview extends Component {
+  static defaultProps = {
+    tabName: 'Diff'
+  }
+
   render() {
     const {
       styling, delta, error, nextState, onInspectPath, inspectedPath, tabName,


### PR DESCRIPTION
Fixes the error `Uncaught TypeError: Cannot read property 'component' of undefined`.