### PR TITLE
Support for time travelling

### DIFF
--- a/src/ActionList.jsx
+++ b/src/ActionList.jsx
@@ -37,7 +37,7 @@ export default class ActionList extends Component {
 
   render() {
     const { styling, actions, actionIds, isWideLayout, onToggleAction, skippedActionIds,
-            selectedActionId, startActionId, onSelect, onSearch, searchValue,
+            selectedActionId, startActionId, onSelect, onSearch, searchValue, currentActionId,
             onCommit, onSweep } = this.props;
     const lowerSearchValue = searchValue && searchValue.toLowerCase();
     const filteredActionIds = searchValue ? actionIds.filter(
@@ -63,6 +63,7 @@ export default class ActionList extends Component {
                             actionId >= startActionId && actionId <= selectedActionId ||
                             actionId === selectedActionId
                            }
+                           isInFuture={actionId > currentActionId}
                            onSelect={(e) => onSelect(e, actionId)}
                            timestamps={getTimestamps(actions, actionIds, actionId)}
                            action={actions[actionId].action}

--- a/src/ActionList.jsx
+++ b/src/ActionList.jsx
@@ -38,7 +38,7 @@ export default class ActionList extends Component {
   render() {
     const { styling, actions, actionIds, isWideLayout, onToggleAction, skippedActionIds,
             selectedActionId, startActionId, onSelect, onSearch, searchValue, currentActionId,
-            onCommit, onSweep } = this.props;
+            onCommit, onSweep, onJumpToState } = this.props;
     const lowerSearchValue = searchValue && searchValue.toLowerCase();
     const filteredActionIds = searchValue ? actionIds.filter(
       id => actions[id].action.type.toLowerCase().indexOf(lowerSearchValue) !== -1
@@ -67,7 +67,8 @@ export default class ActionList extends Component {
                            onSelect={(e) => onSelect(e, actionId)}
                            timestamps={getTimestamps(actions, actionIds, actionId)}
                            action={actions[actionId].action}
-                           onViewClick={() => onToggleAction(actionId)}
+                           onToggleClick={() => onToggleAction(actionId)}
+                           onJumpClick={() => onJumpToState(actionId)}
                            onCommitClick={() => onCommit(actionId)}
                            isSkipped={skippedActionIds.indexOf(actionId) !== -1} />
           )}

--- a/src/ActionListRow.jsx
+++ b/src/ActionListRow.jsx
@@ -4,6 +4,7 @@ import dateformat from 'dateformat';
 import RightSlider from './RightSlider';
 
 const BUTTON_SKIP = 'Skip';
+const BUTTON_JUMP = 'Jump';
 
 export default class ActionListRow extends Component {
   state = { hover: false };
@@ -64,7 +65,7 @@ export default class ActionListRow extends Component {
           </RightSlider>
           <RightSlider styling={styling} shown={showButtons} rotate>
             <div {...styling('actionListItemSelector')}>
-              {[BUTTON_SKIP].map(btn => (!isInitAction || btn !== BUTTON_SKIP) &&
+              {[BUTTON_JUMP, BUTTON_SKIP].map(btn => (!isInitAction || btn !== BUTTON_SKIP) &&
                 <div key={btn}
                      onClick={this.handleButtonClick.bind(this, btn)}
                      {...styling([
@@ -86,7 +87,10 @@ export default class ActionListRow extends Component {
 
     switch(btn) {
     case BUTTON_SKIP:
-      this.props.onViewClick();
+      this.props.onToggleClick();
+      break;
+    case BUTTON_JUMP:
+      this.props.onJumpClick();
       break;
     }
   }

--- a/src/ActionListRow.jsx
+++ b/src/ActionListRow.jsx
@@ -12,6 +12,7 @@ export default class ActionListRow extends Component {
     styling: PropTypes.func.isRequired,
     isSelected: PropTypes.bool.isRequired,
     action: PropTypes.shape({ type: PropTypes.string.isRequired }).isRequired,
+    isInFuture: PropTypes.bool.isRequired,
     isInitAction: PropTypes.bool.isRequired,
     onSelect: PropTypes.func.isRequired,
     timestamps: PropTypes.shape({
@@ -33,7 +34,7 @@ export default class ActionListRow extends Component {
 
   render() {
     const { styling, isSelected, action, isInitAction, onSelect,
-            timestamps, isSkipped } = this.props;
+            timestamps, isSkipped, isInFuture } = this.props;
     const { hover } = this.state;
     const timeDelta = timestamps.current - timestamps.previous;
     const showButtons = hover && !isInitAction || isSkipped;
@@ -48,7 +49,8 @@ export default class ActionListRow extends Component {
            {...styling([
              'actionListItem',
              isSelected && 'actionListItemSelected',
-             isSkipped && 'actionListItemSkipped'
+             isSkipped && 'actionListItemSkipped',
+             isInFuture && 'actionListFromFuture'
            ], isSelected, action)}>
         <div {...styling(['actionListItemName', isSkipped && 'actionListItemNameSkipped'])}>
           {action.type}

--- a/src/DevtoolsInspector.js
+++ b/src/DevtoolsInspector.js
@@ -17,7 +17,7 @@ function getLastActionId(props) {
 
 function getCurrentActionId(props, monitorState) {
   return monitorState.selectedActionId === null ?
-    getLastActionId(props) : monitorState.selectedActionId;
+    props.stagedActionIds[props.currentStateIndex] : monitorState.selectedActionId;
 }
 
 function getFromState(actionIndex, stagedActionIds, computedStates, monitorState) {
@@ -149,10 +149,12 @@ export default class DevtoolsInspector extends Component {
 
   render() {
     const { stagedActionIds: actionIds, actionsById: actions, computedStates,
-      tabs, invertTheme, skippedActionIds, monitorState } = this.props;
+      tabs, invertTheme, skippedActionIds, currentStateIndex, monitorState } = this.props;
     const { selectedActionId, startActionId, searchValue, tabName } = monitorState;
     const inspectedPathType = tabName === 'Action' ? 'inspectedActionPath' : 'inspectedStatePath';
-    const { themeState, isWideLayout, action, nextState, delta, error } = this.state;
+    const {
+      themeState, isWideLayout, action, nextState, delta, error
+    } = this.state;
     const { base16Theme, styling } = themeState;
 
     return (
@@ -169,6 +171,7 @@ export default class DevtoolsInspector extends Component {
                     onCommit={this.handleCommit}
                     onSweep={this.handleSweep}
                     skippedActionIds={skippedActionIds}
+                    currentActionId={actionIds[currentStateIndex]}
                     lastActionId={getLastActionId(this.props)} />
         <ActionPreview {...{
           base16Theme, invertTheme, isWideLayout, tabs, tabName, delta, error, nextState,

--- a/src/DevtoolsInspector.js
+++ b/src/DevtoolsInspector.js
@@ -9,7 +9,7 @@ import { getBase16Theme } from 'react-base16-styling';
 import { reducer, updateMonitorState } from './redux';
 import { ActionCreators } from 'redux-devtools';
 
-const { commit, sweep, toggleAction } = ActionCreators;
+const { commit, sweep, toggleAction, jumpToState } = ActionCreators;
 
 function getLastActionId(props) {
   return props.stagedActionIds[props.stagedActionIds.length - 1];
@@ -168,6 +168,7 @@ export default class DevtoolsInspector extends Component {
                     onSearch={this.handleSearch}
                     onSelect={this.handleSelectAction}
                     onToggleAction={this.handleToggleAction}
+                    onJumpToState={this.handleJumpToState}
                     onCommit={this.handleCommit}
                     onSweep={this.handleSweep}
                     skippedActionIds={skippedActionIds}
@@ -187,6 +188,11 @@ export default class DevtoolsInspector extends Component {
 
   handleToggleAction = actionId => {
     this.props.dispatch(toggleAction(actionId));
+  };
+
+  handleJumpToState = actionId => {
+    const index = this.props.stagedActionIds.indexOf(actionId);
+    if (index > 0) this.props.dispatch(jumpToState(index));
   };
 
   handleCommit = () => {

--- a/src/DevtoolsInspector.js
+++ b/src/DevtoolsInspector.js
@@ -9,7 +9,7 @@ import { getBase16Theme } from 'react-base16-styling';
 import { reducer, updateMonitorState } from './redux';
 import { ActionCreators } from 'redux-devtools';
 
-const { commit, sweep, toggleAction, jumpToState } = ActionCreators;
+const { commit, sweep, toggleAction, jumpToAction, jumpToState } = ActionCreators;
 
 function getLastActionId(props) {
   return props.stagedActionIds[props.stagedActionIds.length - 1];
@@ -191,8 +191,12 @@ export default class DevtoolsInspector extends Component {
   };
 
   handleJumpToState = actionId => {
-    const index = this.props.stagedActionIds.indexOf(actionId);
-    if (index > 0) this.props.dispatch(jumpToState(index));
+    if (jumpToAction) {
+      this.props.dispatch(jumpToAction(actionId));
+    } else { // Fallback for redux-devtools-instrument < 1.5
+      const index = this.props.stagedActionIds.indexOf(actionId);
+      if (index !== -1) this.props.dispatch(jumpToState(index));
+    }
   };
 
   handleCommit = () => {

--- a/src/utils/createStylingFromTheme.js
+++ b/src/utils/createStylingFromTheme.js
@@ -120,6 +120,10 @@ const getSheetFromColorMap = map => ({
     'background-color': map.SKIPPED_BACKGROUND_COLOR
   },
 
+  actionListFromFuture: {
+    opacity: '0.6'
+  },
+
   actionListItemButtons: {
     position: 'relative',
     height: '20px',


### PR DESCRIPTION
- Visually identify actions from the future (as in https://github.com/gaearon/redux-devtools-log-monitor/pull/56).
- Jump to a corresponding state of a specific action (as described in https://github.com/zalmoxisus/redux-devtools-extension/issues/234).

![tt](https://cloud.githubusercontent.com/assets/7957859/21462224/23f6b7ec-c962-11e6-84df-480441ee1849.gif)
