### PR TITLE
Show `undefined` for unserializable by `javascript-stringify` data

### DIFF
--- a/src/tabs/JSONDiff.jsx
+++ b/src/tabs/JSONDiff.jsx
@@ -23,9 +23,10 @@ type State = {
 };
 
 function stringifyAndShrink(val: any, isWideLayout: boolean): string {
-  const str = stringify(val);
   if (val === null) { return 'null'; }
-  else if (typeof val === 'undefined') { return 'undefined'; }
+
+  const str = stringify(val);
+  if (typeof str === 'undefined') { return 'undefined'; }
 
   if (isWideLayout) return str.length > 42 ? str.substr(0, 30) + '…' + str.substr(-10) : str;
   return str.length > 22 ? `${str.substr(0, 15)}…${str.substr(-5)}` : str;


### PR DESCRIPTION
Fix #42.

As discussed in https://github.com/blakeembrey/javascript-stringify/pull/9, `javascript-stringify` is returning `undefined` for unserializable data and when passing `undefined`. So, as described in #42, [we're accessing `length` of `undefined`](https://github.com/alexkuz/redux-devtools-inspector/blob/master/src/tabs/JSONDiff.jsx#L30).