### PR TITLE
Give access to `monitorState` for custom tabs components

### DIFF
--- a/src/ActionPreview.jsx
+++ b/src/ActionPreview.jsx
@@ -36,7 +36,7 @@ class ActionPreview extends Component<DefaultProps, Props, void> {
     const {
       styling, delta, error, nextState, onInspectPath, inspectedPath, tabName,
       isWideLayout, onSelectTab, action, actions, selectedActionId, startActionId,
-      computedStates, base16Theme, invertTheme, tabs
+      computedStates, base16Theme, invertTheme, tabs, monitorState, updateMonitorState
     } = this.props;
 
     const renderedTabs = (typeof tabs === 'function') ?
@@ -72,7 +72,9 @@ class ActionPreview extends Component<DefaultProps, Props, void> {
                   isWideLayout,
                   delta,
                   action,
-                  nextState
+                  nextState,
+                  monitorState,
+                  updateMonitorState
                 }}
               />
             }

--- a/src/DevtoolsInspector.js
+++ b/src/DevtoolsInspector.js
@@ -139,9 +139,9 @@ export default class DevtoolsInspector extends PureComponent<DefaultProps, Props
     clearTimeout(this.updateSizeTimeout);
   }
 
-  updateMonitorState(monitorState: MonitorState) {
+  updateMonitorState = (monitorState: MonitorState) => {
     this.props.dispatch(updateMonitorState(monitorState));
-  }
+  };
 
   updateSizeMode() {
     const isWideLayout = this.refs.inspector.offsetWidth > 500;
@@ -200,8 +200,9 @@ export default class DevtoolsInspector extends PureComponent<DefaultProps, Props
                     lastActionId={getLastActionId(this.props)} />
         <ActionPreview {...{
           base16Theme, invertTheme, isWideLayout, tabs, tabName, delta, error, nextState,
-          computedStates, action, actions, selectedActionId, startActionId
+          computedStates, action, actions, selectedActionId, startActionId, monitorState
         }}
+                       updateMonitorState={this.updateMonitorState}
                        styling={styling}
                        onInspectPath={this.handleInspectPath.bind(this, inspectedPathType)}
                        inspectedPath={monitorState[inspectedPathType]}


### PR DESCRIPTION
It allows submonitors in tabs to have access and update `monitorState`. For example [`redux-devtools-test-generator`](https://github.com/zalmoxisus/redux-devtools-test-generator) can persist test templates. We're not dividing them into substates, so one should do it on the submonitor side [like so](https://github.com/zalmoxisus/redux-devtools-test-generator/blob/master/src/index.js#L82-L89). It could be useful to have access to the whole `monitorState`, for example, [for Chart tab we can switch to other tab when the node is clicked](https://github.com/zalmoxisus/redux-devtools-extension/releases/tag/v2.11.0).