### PR TITLE
Fix overflowing actions list on Firefox

### DIFF
--- a/src/utils/createStylingFromTheme.js
+++ b/src/utils/createStylingFromTheme.js
@@ -48,6 +48,7 @@ const getSheetFromColorMap = map => ({
     'font-size': '12px',
     'font-smoothing': 'antialiased',
     'line-height': '1.5em',
+    'min-height': '0',
 
     'background-color': map.BACKGROUND_COLOR,
     color: map.TEXT_COLOR


### PR DESCRIPTION
Flex items have "min-height: auto" by default. Setting "min-height: 0" allows the inspector to have a height less than the full scroll height.

See:
 - https://github.com/zalmoxisus/redux-devtools-extension/issues/387
 - https://github.com/zalmoxisus/redux-devtools-extension/issues/377