### PR TITLE
 Update react-json-tree dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "jss-vendor-prefixer": "^4.0.0",
     "lodash.debounce": "^4.0.3",
     "react-base16-styling": "^0.4.1",
-    "react-json-tree": "^0.10.5",
+    "react-json-tree": "^0.11.0",
     "redux-devtools-themes": "^1.0.0"
   },
   "pre-commit": [

--- a/src/types.js
+++ b/src/types.js
@@ -5,7 +5,6 @@ export type Action = {
 };
 
 export type TabName = 'Action' | 'Diff' | 'State';
-/* @noflow */
 export type Tab = {
   name: TabName,
   component: React$Component

--- a/src/types.js
+++ b/src/types.js
@@ -1,9 +1,11 @@
+/* @flow */
 export type Action = {
   timestamp: Date,
   error: ?string
 };
 
 export type TabName = 'Action' | 'Diff' | 'State';
+/* @noflow */
 export type Tab = {
   name: TabName,
   component: React$Component


### PR DESCRIPTION
This updates react-json-tree to `v0.11.0` which changes the peerDependancies to include React 16. 

Also fixes some lint errors with a flow declaration.