### PR TITLE
Sort JSON tree keys alphabetically

### DIFF
--- a/src/tabs/ActionTab.jsx
+++ b/src/tabs/ActionTab.jsx
@@ -48,6 +48,7 @@ export default class ActionTab extends PureComponent<void, Props, State> {
         data={action}
         getItemString={this.getItemString}
         invertTheme={invertTheme}
+        sortObjectKeys={(str1, str2) => str1.localeCompare(str2)}
         hideRoot
       />
     );

--- a/src/tabs/JSONDiff.jsx
+++ b/src/tabs/JSONDiff.jsx
@@ -95,6 +95,7 @@ export default class JSONDiff extends PureComponent<void, Props, State> {
         postprocessValue={prepareDelta}
         isCustomNode={Array.isArray}
         shouldExpandNode={expandFirstLevel}
+        sortObjectKeys={(str1, str2) => str1.localeCompare(str2)}
         hideRoot
       />
     );

--- a/src/tabs/StateTab.jsx
+++ b/src/tabs/StateTab.jsx
@@ -47,6 +47,7 @@ export default class StateTab extends PureComponent<void, Props, State> {
         data={nextState}
         getItemString={this.getItemString}
         invertTheme={invertTheme}
+        sortObjectKeys={(str1, str2) => str1.localeCompare(str2)}
         hideRoot
       />
     );


### PR DESCRIPTION
This will sort the JSON tree keys in alphabetical order, rather than with the implementation-dependent ordering determined by the browser engine's `getOwnPropertyNames` function. In large JSON structures, it can be challenging to locate a particular nested node of interest among the multitude of other keys. Adding this sorting will dramatically simplify locating specific state attributes. The request comes from zalmoxisus/redux-devtools-extension#416.

Note that the `localeCompare` function is [supported in all major browsers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare#Browser_compatibility) per MDN. It is case-sensitive, so `abc` will come before `Abc`.

If it's preferable that this be opt-in so as not to upset existing applications, I'm more than happy to make changes as advised. Thanks!